### PR TITLE
Remarque famille orthogonale

### DIFF
--- a/src/q2/math/math.tex
+++ b/src/q2/math/math.tex
@@ -139,9 +139,11 @@
 \begin{mydef}
 	Soient $E$ un espace euclidien et $x_1, x_2,... ,x_n \in E$,
 	\begin{enumerate}
-		\item La famille $x_1, x_2,... ,x_n$ est ume famille orthogonale si
+		\item La famille $x_1, x_2,... ,x_n$ est une famille orthogonale si
 			\begin{itemize}
-				\item $x_i \neq 0, \forall i$;
+				\item $x_i \neq 0, \forall i$ 
+				\footnote{Plus tard, on parlera de base orthogonale, or 0 ne peut
+				pas faire partie d'une base, d'où cette condition.};
 				\item $x_i \perp x_j, \forall i \neq j$.
 			\end{itemize}
 


### PR DESCRIPTION
Petite explication concernant la première condition de la définition d'une famille orthogonale (+ correction d'une petite faute de frappe).
