### PR TITLE
Ajout schéma de synthèse sur les liaisons

### DIFF
--- a/src/q2/chimie/chimie.tex
+++ b/src/q2/chimie/chimie.tex
@@ -7,6 +7,7 @@
 \usepackage{tikz}
 \usepackage{pgfplots}
 \usepackage{pgffor}
+\usepackage{qtree}
 
 \renewcommand{\textbf}[1]{\begingroup\bfseries\mathversion{bold}#1\endgroup}
 
@@ -775,6 +776,10 @@ Si la condition est respectée et qu'il y a plusieurs \ce{F}, \ce{O}, \ce{N} ou 
   \item \ce{CH3COOH}
   \item \ce{NH2OH}
 \end{itemize}
+
+\section{Synthèse sur les liaisons chimiques}
+
+Voir \sectionref{synthese_liaisons} dans les annexes.
 
 \part{Chimie du solide (Uniquement pour Projet)}
 Dans cette section,
@@ -1833,6 +1838,16 @@ $v_r$ les coefficients des réactifs,
 Si des molécules sont déjà dans les états voulus,
 on a juste
 \[ \Delta H = \sum v_r{E_l}_\mathrm{réactifs} - \sum v_p{E_l}_\mathrm{produits} \]
+
+\section{Schéma de synthèse sur les liaisons chimiques}
+\label{sec:synthese_liaisons}
+
+\rotatebox{90}
+{\Tree [.{Liaisons chimiques} [.{Intramoléculaires \\ $E_L > \numprint[\kilo\joule\per\mole]{40}$} 
+Métalliques [.{Covalentes \\ $\Delta \chi < 1,5$} {Pures \\ $\Delta \chi = 0$} Polarisées 
+Datives ] {Ioniques \\ $\Delta \chi > 2$} ] [.{Intermoléculaires \\ $E_L < \numprint[\kilo\joule\per\mole]{40}$} 
+[.{Van der Waals} {Keesom \\ Permanent-permanent} {Debye \\ Permanent-induit} {London \\ Induit-induit} ] 
+{Ponts H \\ \ce{H} et \ce{F}, \ce{O}, \ce{N}} ] ]}
 
 \biblio
 \end{document}


### PR DESCRIPTION
Je l'ai finalement ajouté dans les annexes comme le schéma prend une page complète. Seulement il y a une page blanche qui s’intercale entre les deux dernières annexes, je sais pas comment ça se fait et je ne sais pas comment l'enlever (si c'est possible)
