### PR TITLE
Corrections differentielle

### DIFF
--- a/src/q2/math/math.tex
+++ b/src/q2/math/math.tex
@@ -1168,9 +1168,9 @@ Dans cette partie, on considère $f$, une fonction telle que
 
 \begin{myform}
 	Si $f$ est \textbf{différentiable} au point $a$, on a
-	\[ Df_d(a) = \dif f_a(d) \]
+	\[ D_df(a) = \dif f_a(d) \]
 	Si $f$ n'est \textbf{pas différentiable} au point $a$, on a \textbf{pas} spécialement
-	\[ Df_d(a) = \sum_{i = 1}^n \frac{\partial f}{\partial x_i}d_i \]
+	\[ D_df(a) = \sum_{i = 1}^n \frac{\partial f}{\partial x_i}(a)d_i \]
 	Si vous utilisez cette formule, il ne faut pas oublier de mentionner le fait que $f$ est différentiable au point $a$
 	et de le montrer si ce n'est pas déjà fait.
 \end{myform}


### PR DESCRIPTION
Je pense qu'il y a une petite erreur de notation pour la dérivée directionnelle de 'f' en 'a' dans la direction de 'd' , la notation utilisée est différente de celle aux autres endroits de la synthèse et me parait fausse :)
Je pense aussi qu'un argument '(a)' est oublié devant une dérivée partielle.
