### PR TITLE
Angström

### DIFF
--- a/src/q3/physique/physique.tex
+++ b/src/q3/physique/physique.tex
@@ -1320,7 +1320,7 @@ $f(E_F) = \frac{1}{2}$.
 En physique quantique, il y a deux unités souvent utilisées:
 \begin{itemize}
 \item le Hartree ($1Ha =  4,36\cdot 10^{-18} J$)
-\item le Alchtreum ($1 \dot{A} = 10^{-10} m$)
+\item le \AA ngstr\"om ($1 \AA = 10^{-10} m$)
 \end{itemize}
 
 \section{Dérivation simple des équations de Schrödinger}


### PR DESCRIPTION
10^-10 m est appelé un Angström en l'honneur du physicien suédois qui fonda la spectroscopie (http://fr.wikipedia.org/wiki/%C3%85ngstr%C3%B6m). Il existe ne LaTeX un symbole spécifique pour (\AA). Il était noté Alchtreum qui est tout à fait faux et le symbole était \dot{A} (un point) et nom \AA, le A avec un rond suédois dessus.