### PR TITLE
Fix typo SIGALRM

### DIFF
--- a/src/q4/os/os.tex
+++ b/src/q4/os/os.tex
@@ -1833,7 +1833,7 @@ L'OS prévoit par défaut le traitement de tous les signaux, mais il est possibl
 \begin{tabularx}{\textwidth}{l|p{0.615\textwidth}|c}
   \textbf{Signal} & \textbf{Provoqué lorsqu'une} & \textbf{Par défaut} \\
   \hline \hline
-  \texttt{SIGALARM} & Une alarme définie par la fonction \texttt{alarm} ou \texttt{setitimer} a expiré. & Terminaison \\
+  \texttt{SIGALRM} & Une alarme définie par la fonction \texttt{alarm} ou \texttt{setitimer} a expiré. & Terminaison \\
   \hline
   \texttt{SIGBUS} & Erreur au niveau matériel & Terminaison \\
   \hline


### PR DESCRIPTION
Correction dans le cours d'OS Unix d'une typo classique sur le nom du signal d'alarme.
Il ne contient qu'un seul A.