### PR TITLE
Fix some clashes between tikz and babel

### DIFF
--- a/src/eplbase.cls
+++ b/src/eplbase.cls
@@ -63,7 +63,7 @@
 \RequirePackage{multicol}
 
 \RequirePackage{tikz}
-\usetikzlibrary{positioning, calc}
+\usetikzlibrary{positioning, calc, babel}
 
 \RequirePackage{pdfpages}
 %\usepackage{subfig}


### PR DESCRIPTION
This isn't loaded by default with tikz since it might break some really old code. It didn't cause any regression on my machine while allowing some documents that uses circuitikz to compile.