### PR TITLE
Move repository under CC-BY-SA 4.0

### DIFF
--- a/LICENSE_CC_BY_SA.txt
+++ b/LICENSE_CC_BY_SA.txt
@@ -1,0 +1,103 @@
+Creative Commons Attribution-ShareAlike 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution-ShareAlike 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+
+Section 1 – Definitions.
+
+    Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+    Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+    BY-SA Compatible License means a license listed at creativecommons.org/compatiblelicenses, approved by Creative Commons as essentially the equivalent of this Public License.
+    Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+    Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+    Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+    License Elements means the license attributes listed in the name of a Creative Commons Public License. The License Elements of this Public License are Attribution and ShareAlike.
+    Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+    Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+    Licensor means the individual(s) or entity(ies) granting rights under this Public License.
+    Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+    Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+    You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
+
+Section 2 – Scope.
+
+    License grant.
+        Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+            reproduce and Share the Licensed Material, in whole or in part; and
+            produce, reproduce, and Share Adapted Material.
+        Exceptions and Limitations. For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+        Term. The term of this Public License is specified in Section 6(a).
+        Media and formats; technical modifications allowed. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+        Downstream recipients.
+            Offer from the Licensor – Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+            Additional offer from the Licensor – Adapted Material. Every recipient of Adapted Material from You automatically receives an offer from the Licensor to exercise the Licensed Rights in the Adapted Material under the conditions of the Adapter’s License You apply.
+            No downstream restrictions. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+        No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
+
+    Other rights.
+        Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+        Patent and trademark rights are not licensed under this Public License.
+        To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
+
+Section 3 – License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+
+    Attribution.
+
+        If You Share the Licensed Material (including in modified form), You must:
+            retain the following if it is supplied by the Licensor with the Licensed Material:
+                identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+                a copyright notice;
+                a notice that refers to this Public License;
+                a notice that refers to the disclaimer of warranties;
+                a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+            indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+            indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+        You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+        If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+    ShareAlike.
+
+    In addition to the conditions in Section 3(a), if You Share Adapted Material You produce, the following conditions also apply.
+        The Adapter’s License You apply must be a Creative Commons license with the same License Elements, this version or later, or a BY-SA Compatible License.
+        You must include the text of, or the URI or hyperlink to, the Adapter's License You apply. You may satisfy this condition in any reasonable manner based on the medium, means, and context in which You Share Adapted Material.
+        You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, Adapted Material that restrict exercise of the rights granted under the Adapter's License You apply.
+
+Section 4 – Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+
+    for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;
+    if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material, including for purposes of Section 3(b); and
+    You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+
+Section 5 – Disclaimer of Warranties and Limitation of Liability.
+
+    Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.
+    To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.
+
+    The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+
+Section 6 – Term and Termination.
+
+    This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+
+    Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+        automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+        upon express reinstatement by the Licensor.
+    For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+    For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+    Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+
+Section 7 – Other Terms and Conditions.
+
+    The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+    Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+
+Section 8 – Interpretation.
+
+    For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+    To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+    No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+    Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Vous pouvez visualiser le statut des différentes synthèses
 [ici](https://github.com/Gp2mv3/Syntheses/wiki/Status).
 N'hésitez pas à en rajouter dans la liste :)
 
+## License
+Sauf mention expresse, vous licensiez sous license [CC-BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/)
+tout le contenu que vous soumettez pour inclusion dans ce dépot.
+
+Si cette license vous pose problème, venez en discuter en ouvrant une [issue](https://github.com/Gp2mv3/Syntheses/issues/new).
+
 ## Copier les synthèses à leur destination
 Vous pouvez copier les synthèses automatiquement vers leur destination à l'aide de `make release` mais pour cela il vous faut d'abord spécifier les destination dans un fichier de configuration `src/config.yml` et installer
 [`smartcp`](https://github.com/blegat/smartcp).

--- a/src/eplbase.cls
+++ b/src/eplbase.cls
@@ -12,6 +12,7 @@
 % If you want to compile without it
 \DeclareOption{skiptoc}{\newcommand{\skiptableofcontents}{}}
 \DeclareOption{skiptitle}{\newcommand{\skiptitlepage}{}}
+\DeclareOption{license=none}{\newcommand{\nolicense}{}}
 
 \DeclareOption{usereportclass}{\newcommand{\usereport}{}}
 \DeclareOption{10pt}{
@@ -215,6 +216,17 @@
    changements par mail ou par n'importe quel autre moyen.}
 
    #9
+
+    \ifthenelse{\isundefined{\nolicense}}{
+        \bigskip
+        \paragraph{License} \IfLanguageName{english}
+        {This work is licensed under the Creative Commons Attribution 4.0 Unported License.
+            To view a copy of this license, visit \url{http://creativecommons.org/licenses/by/4.0/},
+        or look into the github repository (see above).}
+        {Ce travail est disponible sous license Creative Commons Attribution 4.0 Unported.
+            Une copie de cette license est disponible sur \url{http://creativecommons.org/licenses/by/4.0/},
+        on dans le dépot github (voir ci-dessus).}
+    }{}
 \end{titlepage}
 }{}
 

--- a/src/eplexam.cls
+++ b/src/eplexam.cls
@@ -1,6 +1,17 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesClass{eplexam}[2015/03/06 EPL exam class]
 
+% We do not license exams under CC-BY-SA since part of
+% the documents are work of professors.
+
+% I need to pass license=none to eplbase so I cannot just do
+% \LoadClassWithOptions because it ignores \PassOptionsToClass.
+% I need to pass every option manually with the 2 following lines
+% and then use \LoadClass
+\DeclareOption*{\PassOptionsToClass{\CurrentOption}{../../../../../../eplbase}}
+\ProcessOptions\relax
+\PassOptionsToClass{license=none}{../../../../../../eplbase}
+
 \LoadClassWithOptions{../../../../../../epleval}
 
 \IfLanguageName{english}{\newcommand{\Epltype}{Exam}\newcommand{\epltype}{exam}}{\newcommand{\Epltype}{Examen}\newcommand{\epltype}{examen}}

--- a/src/q1/elec-FSAB1201/exam/2015/Janvier/All/elec-FSAB1201-exam-2015-Janvier-All.tex
+++ b/src/q1/elec-FSAB1201/exam/2015/Janvier/All/elec-FSAB1201-exam-2015-Janvier-All.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../../../../eplexam}
+\documentclass[fr,license=none]{../../../../../../eplexam}
 
 \usepackage{enumerate}
 \usepackage{circuitikz}

--- a/src/q1/elec-FSAB1201/summary/elec-FSAB1201-summary.tex
+++ b/src/q1/elec-FSAB1201/summary/elec-FSAB1201-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{array}
 \usepackage{fancybox}

--- a/src/q1/math-FSAB1101/summary/math-FSAB1101-summary.tex
+++ b/src/q1/math-FSAB1101/summary/math-FSAB1101-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 %\usepackage[hideerrors]{xcolor}
 \usepackage{array}

--- a/src/q1/meca-FSAB1201/summary/meca-FSAB1201-summary.tex
+++ b/src/q1/meca-FSAB1201/summary/meca-FSAB1201-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,licence=none]{../../../eplsummary}
 
 \usepackage{tikz}
 \usepackage{../../../eplunits}

--- a/src/q2/chimie-FSAB1301/notes/chimie-FSAB1301-notes.tex
+++ b/src/q2/chimie-FSAB1301/notes/chimie-FSAB1301-notes.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplnotes}
+\documentclass[fr,license=none]{../../../eplnotes}
 \usepackage{float}
 \usepackage[version=3]{mhchem}
 \usepackage{pgfplots}

--- a/src/q2/chimie-FSAB1301/summary/chimie-FSAB1301-summary.tex
+++ b/src/q2/chimie-FSAB1301/summary/chimie-FSAB1301-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{../../../eplchem}
 \usepackage[SIunits]{../../../eplunits}

--- a/src/q2/elec-FSAB1202/summary/elec-FSAB1202-summary.tex
+++ b/src/q2/elec-FSAB1202/summary/elec-FSAB1202-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{../../../eplelec}
 \usepackage{../../../eplunits}

--- a/src/q2/math-FSAB1102/notes/math-notes.tex
+++ b/src/q2/math-FSAB1102/notes/math-notes.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplnotes}
+\documentclass[fr,license=none]{../../../eplnotes}
 
 \usepackage{graphicx}
 

--- a/src/q2/math-FSAB1102/summary/math-summary.tex
+++ b/src/q2/math-FSAB1102/summary/math-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{tensor}
 \usepackage{array}

--- a/src/q2/philo-FSAB1802/summary/philo-summary.tex
+++ b/src/q2/philo-FSAB1802/summary/philo-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{tikz}
 \usepackage{wasysym}

--- a/src/q3/chimie-FSAB1302/summary/chimie-FSAB1302-summary.tex
+++ b/src/q3/chimie-FSAB1302/summary/chimie-FSAB1302-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{esint}
 \usepackage{esvect}

--- a/src/q3/info-FSAB1402/exercises/info-FSAB1402-exercises.tex
+++ b/src/q3/info-FSAB1402/exercises/info-FSAB1402-exercises.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplexercises}
+\documentclass[fr,license=none]{../../../eplexercises}
 
 \usepackage{../../../eplcode}
 

--- a/src/q3/info-FSAB1402/summary/info-FSAB1402-summary.tex
+++ b/src/q3/info-FSAB1402/summary/info-FSAB1402-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{../../../eplcode}
 

--- a/src/q4/coo/summary/coo-summary.tex
+++ b/src/q4/coo/summary/coo-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{../../../eplcode}
 \usepackage{../../../eplunits}

--- a/src/q4/dam-MECA1210/notes/dam-MECA1210-notes.tex
+++ b/src/q4/dam-MECA1210/notes/dam-MECA1210-notes.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplnotes}
+\documentclass[fr,license=none]{../../../eplnotes}
 
 \usepackage{graphicx}
 \usepackage{wrapfig}

--- a/src/q4/eco/summary/eco-summary.tex
+++ b/src/q4/eco/summary/eco-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{graphicx}
 

--- a/src/q4/edo-MAT1223/exercises/edo-MAT1223-exercises.tex
+++ b/src/q4/edo-MAT1223/exercises/edo-MAT1223-exercises.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplexercises}
+\documentclass[fr,license=none]{../../../eplexercises}
 
 \usepackage{wasysym}
 \usepackage{bm}

--- a/src/q4/fem-MECA1120/summary/fem-MECA1120-summary.tex
+++ b/src/q4/fem-MECA1120/summary/fem-MECA1120-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 %\usepackage{MnSymbol}
 \makeatletter

--- a/src/q4/geomat-AUCE1171/summary/geomat-AUCE1171-summary.tex
+++ b/src/q4/geomat-AUCE1171/summary/geomat-AUCE1171-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr,usereportclass]{../../../eplsummary}
+\documentclass[fr,usereportclass,license=none]{../../../eplsummary}
 
 \usepackage[SIunits]{../../../eplunits}
 

--- a/src/q4/os-SINF1225/summary/os-SINF1225-summary.tex
+++ b/src/q4/os-SINF1225/summary/os-SINF1225-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{multirow}
 \usepackage{wrapfig}

--- a/src/q5/algo-SINF1121/summary/algo-SINF1121-summary.tex
+++ b/src/q5/algo-SINF1121/summary/algo-SINF1121-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[en]{../../../eplsummary}
+\documentclass[en,license=none]{../../../eplsummary}
 
 \usepackage{../../../eplcommon}
 \usepackage{../../../eplcode}

--- a/src/q5/dispo-ELEC1330/summary/dispo-ELEC1330-summary.tex
+++ b/src/q5/dispo-ELEC1330/summary/dispo-ELEC1330-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{../../../eplunits}
 \usepackage{../../../eplelec}

--- a/src/q5/magn-ELEC1350/summary/magn-ELEC1350-summary.tex
+++ b/src/q5/magn-ELEC1350/summary/magn-ELEC1350-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{../../../eplunits}
 \usepackage{../../../eplelec}

--- a/src/q5/mmc-MECA1901/summary/mmc-MECA1901-summary.tex
+++ b/src/q5/mmc-MECA1901/summary/mmc-MECA1901-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{graphicx}
 

--- a/src/q5/network-INGI1341/summary/network-INGI1341-summary.tex
+++ b/src/q5/network-INGI1341/summary/network-INGI1341-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[en]{../../../eplsummary}
+\documentclass[en,license=none]{../../../eplsummary}
 
 \usepackage{multirow}
 \usepackage{multicol}

--- a/src/q5/os-INGI1113/summary/os-INGI1113-summary.tex
+++ b/src/q5/os-INGI1113/summary/os-INGI1113-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{../../../eplcode}
 

--- a/src/q5/stat-FSAB1105/formulaire1/stat-FSAB1105-formulaire.tex
+++ b/src/q5/stat-FSAB1105/formulaire1/stat-FSAB1105-formulaire.tex
@@ -1,4 +1,4 @@
-\documentclass[10pt,landscape,en]{../../../eplformulaire}
+\documentclass[10pt,landscape,en,license=none]{../../../eplformulaire}
 
 \usepackage{../stat-FSAB1105}
 

--- a/src/q5/stat-FSAB1105/summary/stat-FSAB1105-summary.tex
+++ b/src/q5/stat-FSAB1105/summary/stat-FSAB1105-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \def\Perp{\perp\!\!\!\perp}
 \newcommand{\E}{\mathbb{E}}

--- a/src/q5/tdo-ECGE1317/notes/tdo-ECGE1317-notes.tex
+++ b/src/q5/tdo-ECGE1317/notes/tdo-ECGE1317-notes.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{enumitem}
 \usepackage[babel=true]{csquotes}

--- a/src/q6/calcu-INGI1123/exercises/calcu-INGI1123-exercises.tex
+++ b/src/q6/calcu-INGI1123/exercises/calcu-INGI1123-exercises.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplexercises}
+\documentclass[fr,license=none]{../../../eplexercises}
 
 
 \usepackage{listings}

--- a/src/q6/calcu-INGI1123/mcq/calcu-INGI1123-mcq.tex
+++ b/src/q6/calcu-INGI1123/mcq/calcu-INGI1123-mcq.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplmcq}
+\documentclass[fr,license=none]{../../../eplmcq}
 
 \hypertitle{Calculabilité}{6}{INGI}{1123}
 {Aymeric \bsc{De Cocq} \and Léonard \bsc{Julémont}\and Benoît Legat\and Aloïs Paulus\and Florian \bsc{Thuin}}

--- a/src/q6/calcu-INGI1123/summary/calcu-INGI1123-summary.tex
+++ b/src/q6/calcu-INGI1123/summary/calcu-INGI1123-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{../../../eplcode}
 

--- a/src/q6/mana-ECGE1321/notes/mana-ECGE1321-notes.tex
+++ b/src/q6/mana-ECGE1321/notes/mana-ECGE1321-notes.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplnotes}
+\documentclass[fr,license=none]{../../../eplnotes}
 
 \usepackage{placeins}
 

--- a/src/q6/mcp-INGI1122/exercises/mcp-INGI1122-exercises.tex
+++ b/src/q6/mcp-INGI1122/exercises/mcp-INGI1122-exercises.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplexercises}
+\documentclass[fr,license=none]{../../../eplexercises}
 
 \usepackage{enumitem} % Enumeration avec des lettres
 \usepackage{listings} % Code

--- a/src/q6/mcp-INGI1122/summary/mcp-INGI1122-summary.tex
+++ b/src/q6/mcp-INGI1122/summary/mcp-INGI1122-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{amsfonts}
 \usepackage{pict2e}

--- a/src/q6/oz-INGI1131/exercises/oz-INGI1131-exercises.tex
+++ b/src/q6/oz-INGI1131/exercises/oz-INGI1131-exercises.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplexercises}
+\documentclass[fr,license=none]{../../../eplexercises}
 
 \usepackage{../../../eplcode}
 

--- a/src/q6/oz-INGI1131/summary/oz-INGI1131-summary.tex
+++ b/src/q6/oz-INGI1131/summary/oz-INGI1131-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{../../../eplcode}
 

--- a/src/q6/telecom-ELEC1930/summary/telecom-ELEC1930-summary.tex
+++ b/src/q6/telecom-ELEC1930/summary/telecom-ELEC1930-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{bm}
 \usepackage{float}

--- a/src/q7/advSecu-INGI2144/summary/advSecu-INGI2144-summary.tex
+++ b/src/q7/advSecu-INGI2144/summary/advSecu-INGI2144-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[en]{../../../eplsummary}
+\documentclass[en,license=none]{../../../eplsummary}
 \usepackage{tikz}
 \usepackage{listings}
 \usepackage[siunitx]{circuitikz}

--- a/src/q7/algo-INGI2266/summary/algo-INGI2266-summary.tex
+++ b/src/q7/algo-INGI2266/summary/algo-INGI2266-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[en]{../../../eplsummary}
+\documentclass[en,license=none]{../../../eplsummary}
 \usepackage{framed}
 \usepackage{placeins}
 \usepackage{listings}

--- a/src/q7/cloud-INGI2145/summary/cloud-INGI2145-summary.tex
+++ b/src/q7/cloud-INGI2145/summary/cloud-INGI2145-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[en]{../../../eplsummary}
+\documentclass[en,license=none]{../../../eplsummary}
 \usepackage{listings}
 
 \usetikzlibrary{calc, trees, positioning, arrows, shapes, shapes.multipart, shadows, matrix, decorations.pathreplacing, decorations.pathmorphing}

--- a/src/q7/concurrent-INGI2143/summary/concurrent-INGI2143-summary.tex
+++ b/src/q7/concurrent-INGI2143/summary/concurrent-INGI2143-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[en]{../../../eplsummary}
+\documentclass[en,license=none]{../../../eplsummary}
 
 \usepackage{../../../eplcode}
 

--- a/src/q7/grh-LSMG2004/summary/grh-LSMG2004-summary.tex
+++ b/src/q7/grh-LSMG2004/summary/grh-LSMG2004-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \usepackage{graphicx}
 \usepackage{multicol}

--- a/src/q7/ia-INGI2261/summary/ia-INGI2261-summary.tex
+++ b/src/q7/ia-INGI2261/summary/ia-INGI2261-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[en]{../../../eplsummary}
+\documentclass[en,license=none]{../../../eplsummary}
 
 \usepackage{csquotes}
 \usepackage{graphicx}

--- a/src/q7/matrix-INMA2380/summary/matrix-INMA2380-summary.tex
+++ b/src/q7/matrix-INMA2380/summary/matrix-INMA2380-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \hypertitle{Théorie des matrices}{7}{INMA}{2380}
 {Yannick Tivisse}

--- a/src/q7/ml-ELEC2870/summary/ml-ELEC2870-summary.tex
+++ b/src/q7/ml-ELEC2870/summary/ml-ELEC2870-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[en]{../../../eplsummary}
+\documentclass[en,license=none]{../../../eplsummary}
 \usepackage{../../../eplcode}
 
 \usepackage{esdiff}

--- a/src/q7/opti-INMA2471/summary/opti-INMA2471-summary.tex
+++ b/src/q7/opti-INMA2471/summary/opti-INMA2471-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[en]{../../../eplsummary}
+\documentclass[en,license=none]{../../../eplsummary}
 
 \usepackage{enumerate}
 \usepackage{diagbox}

--- a/src/q8/constraint-INGI2365/summary/constraint-INGI2365-summary.tex
+++ b/src/q8/constraint-INGI2365/summary/constraint-INGI2365-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[en]{../../../eplsummary}
+\documentclass[en,license=none]{../../../eplsummary}
 
 \usepackage{listings}
 

--- a/src/q8/database-INGI2172/summary/database-INGI2172-summary.tex
+++ b/src/q8/database-INGI2172/summary/database-INGI2172-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \renewcommand{\labelitemi}{$\bullet$}
 \renewcommand{\labelitemii}{$\cdot$}

--- a/src/q8/distributed-SINF2345/summary/distributed-SINF2345-summary.tex
+++ b/src/q8/distributed-SINF2345/summary/distributed-SINF2345-summary.tex
@@ -1,5 +1,5 @@
 
-\documentclass[en]{../../../eplsummary}
+\documentclass[en,license=none]{../../../eplsummary}
 \usepackage{listings}
 
 \usepackage{caption}

--- a/src/q8/network2-INGI2142/notes/network2-INGI2142-notes.tex
+++ b/src/q8/network2-INGI2142/notes/network2-INGI2142-notes.tex
@@ -1,4 +1,4 @@
-\documentclass[en]{../../../eplnotes}
+\documentclass[en,license=none]{../../../eplnotes}
 
 \hypertitle{network2-INGI2142}{8}{INGI}{2142}
 {Houtain Nicolas, Gorby Nicolase Kabasele Ndondas}

--- a/src/q8/secu-INGI2347/summary/secu-INGI2347-summary.tex
+++ b/src/q8/secu-INGI2347/summary/secu-INGI2347-summary.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 
 \newcommand{\syn}{\mathsf{SYN}}
 \newcommand{\ack}{\mathsf{ACK}}

--- a/src/q8/translators-INGI2132/summary/translators-INGI2132-summary.tex
+++ b/src/q8/translators-INGI2132/summary/translators-INGI2132-summary.tex
@@ -1,4 +1,4 @@
-	\documentclass[fr]{../../../eplsummary}
+\documentclass[fr,license=none]{../../../eplsummary}
 \usepackage[french]{varioref} % \vref and \vpageref
 \usepackage{graphicx} % images
 \usepackage{float} % images


### PR DESCRIPTION
Début d'implémentation de #303
+ eplbase.cls ajoute par défaut la license CC-BY-SA
+ eplexam.cls n'ajoute pas la license
+ mention de la license dans le README
+ ajout du texte complet de la license
+ modification de tous les fichiers .tex pour supprimer la license, si les auteurs n'ont pas encore donné leur accord.