### PR TITLE
LELEC1930 Corrections et rajout d'une définition

### DIFF
--- a/src/q6/telecom-ELEC1930/summary/telecom-ELEC1930-summary.tex
+++ b/src/q6/telecom-ELEC1930/summary/telecom-ELEC1930-summary.tex
@@ -688,6 +688,12 @@ $$Gain = \frac{puissance\ dans\ direction\ de\ puissance\ maximum}{puissance\ da
 \end{tikzpicture}
 \end{center}
 
+\begin{description}
+	\item[La puissance isotrope rayonnée équivalente] est la puissance qu'il faudrait appliquer à une antenne isotrope pour obtenir le même champ dans la direction de puissance maximum d'une antenne d'émission.
+\end{description}
+On peut le mesurer comme suit, avec $P_T$ la puissance à l'émission et $G_T$ le gain à l'émission :
+$$ EIRP = P_T \times G_T $$
+
 Voici différents types d'antenne:
 \begin{itemize}
 \item Dipole $\lambda/2$
@@ -973,7 +979,7 @@ $$\omega (t) = \omega_c + ks(t)$$
 Nous allons poser dans un signal $cos(\omega t + \varphi)$, la \textbf{fréquence instantané} $\beta$, tel que:
 $$\beta (t) = \omega t + \varphi$$
 Bien evidemment apres modulation la fréquence instantané vaut:
-$$\beta (t) = \omega_c t + k s(t)( + \varphi_c$$
+$$\beta (t) = \omega_c t + k \int s(t) dt + \varphi_c$$
 On a aussi la relation:
 $$\omega (t) = \frac{d\beta (t)}{dt}$$
 


### PR DESCRIPTION
- Correction de la fréquence instantanée section 4.3 => Il manquait une intégrale et une parenthèse de trop
- Rajout de la définition d'EIRP section 3.5 => surement vu à partir de cette année