### PR TITLE
Corrections Synthèse Q4 SINF1252 OS

### DIFF
--- a/src/q4/os-SINF1225/summary/os-SINF1225-summary.tex
+++ b/src/q4/os-SINF1225/summary/os-SINF1225-summary.tex
@@ -2100,13 +2100,13 @@ En pratique les pipes sont utilisés par le shell avec \texttt{|}. Exemple : \te
   \includegraphics[width=0.5\textwidth]{mmu}
   \caption{\label{fig:mmu}\textit{MMU} et mémoire virtuelle}
 \end{wrapfigure}
-Avec la \textit{\textbf{mémoire virtuelle}}, deux types d'adresse sont utilisées su le système : Les \textit{adresses virtuelles} et les adresse réelles ou physiques. Une \textit{\textbf{adresse virtuelle}} est une adresse qui est utilisée à l'intérieur d'un programme.  Une \textit{\textbf{adresse physique}} est l'adresse qui est utilisée au niveau des puces de RAM pour les opérations d'écriture et de lecture. Ce sont les adresses physiques qui sont échangées sur le bus auquel la mémoire est connectée. \\
-Le rôle du \textit{\textbf{MMU}} ou \textbf{\textit{Memory Management Unit}} est de traduire les adresse virtuelles en adresse physiques. \\
+Avec la \textit{\textbf{mémoire virtuelle}}, deux types d'adresse sont utilisées sur le système : les \textit{adresses virtuelles} et les adresses réelles ou physiques. Une \textit{\textbf{adresse virtuelle}} est une adresse qui est utilisée à l'intérieur d'un programme.  Une \textit{\textbf{adresse physique}} est l'adresse qui est utilisée au niveau des puces de RAM pour les opérations d'écriture et de lecture. Ce sont les adresses physiques qui sont échangées sur le bus auquel la mémoire est connectée. \\
+Le rôle du \textit{\textbf{MMU}} ou \textbf{\textit{Memory Management Unit}} est de traduire les adresses virtuelles en adresses physiques. \\
 
-La longueur des adresses virtuelles et des adresses physiques ne doit pas nécessairement être de la même. Sur les ordinateurs bons marchés par exemple, les adresses virtuelles sont plus longues; ils utilisent une quantité réduite de mémoire RAM. Inversement on peut utiliser des adresses physiques plus langues que les adresses virtuelles (sur les serveurs par exemple).\\
+La longueur des adresses virtuelles et la longueur des adresses physiques ne doivent pas être nécessairement identiques. Sur les ordinateurs bons marchés par exemple, les adresses virtuelles sont plus longues; ils utilisent une quantité réduite de mémoire RAM. Inversement on peut utiliser des adresses physiques plus longues que les adresses virtuelles (sur les serveurs par exemple).\\
 
-Un autre avantage de la mémoire virtuelle est qu'elle permet, à condition de pouvoir avoir une conversion spécifique à  chaque processus, de partager efficacement la mémoire entre processus tout en leur permettant d'utiliser les mêmes adresses virtuelles. \\
-Le \textit{MMU} est capable d'effectuer des traductions d'adresses virtuelles spécifiques à chaque processus ce qui permet non seulement que 2 adresses virtuelles identiques pointe vers 2 adresses physiques différentes mais aussi que 2 adresses virtuelles différentes puisse pointer vers 1 adresse physique (utile pour éviter de copier les librairies partagées) \\
+Un autre avantage de la mémoire virtuelle est qu'elle permet, à condition de pouvoir avoir une conversion spécifique à chaque processus, de partager efficacement la mémoire entre processus tout en leur permettant d'utiliser les mêmes adresses virtuelles. \\
+Le \textit{MMU} est capable d'effectuer des traductions d'adresses virtuelles spécifiques à chaque processus ce qui permet non seulement que 2 adresses virtuelles identiques pointent vers 2 adresses physiques différentes mais aussi que 2 adresses virtuelles différentes puissent pointer vers 1 adresse physique (utile pour éviter de copier les librairies partagées) \\
 \subsection{La mémoire virtuelle}
 \begin{wrapfigure}{r}{0.5\textwidth}
   \vspace{-0.5cm}
@@ -2116,14 +2116,14 @@ Le \textit{MMU} est capable d'effectuer des traductions d'adresses virtuelles sp
 Un autre avantage encore est la possibilité de combiner mémoire RAM et dispositif de stockage (disque dur, disque SSD,...) pour obtenir une mémoire virtuelle de plus grande capacité que la mémoire RAM.
 
 \subsubsection{Fonctionnement de la mémoire virtuelle}
-La difficulté de gestion est que la mémoire est organisé en octet tandis que les dispositifs de stockage utilisent des secteurs de données. Le temps d'accès diffèrent également.\\
+La difficulté de gestion est que la mémoire est organisée en octet tandis que les dispositifs de stockage utilisent des secteurs de données. Le temps d'accès diffèrent également.\\
 
 (ici je comprends pas trop dans le syllabus... j'ai l'impression qu'il manque une partie)\\
 
 Lorsqu'un programme est chargé en mémoire (\texttt{execve}), il est automatiquement découpé en pages. Ces pages peuvent être stockée dans n'importe quelle zone de la mémoire RAM mais doivent être à des adresses qui sont contiguës. Une \textit{adresse virtuelle} est alors composée d'un ensemble de bits. Les bits de poids fort identifient la \textit{page}, tandis que ceux de poids faible identifient la position de la donnée par rapport au début de cette \textit{page}.\\
-\begin{figure}
+\begin{figure}[!h]
   \centering
-  \includegraphics[width=0.5\textwidth]{memtradadresses}[!h]
+  \includegraphics[width=0.5\textwidth]{memtradadresses}
   \caption{Traduction d'adresses avec une table des pages}
 \end{figure}\\
 Avec ce principe de \textit{pages}, un mécanisme de traduction d'adresses peut se baser sur une \textit{\textbf{table de pages}}. Cette \textit{table de pages} est stockée en mémoire RAM et contient une ligne pour chaque page existant dans la mémoire virtuelle. Cette table de page contient :
@@ -2133,7 +2133,7 @@ Avec ce principe de \textit{pages}, un mécanisme de traduction d'adresses peut 
   \item des bits de permission géré par l'OS : \textit{R} bit (lecture), \textit{W} bit (écriture) et \textit{X} bit (exécution)
 \end{itemize}
 
-L'adresse de la table des pages est stockés dans un registre du processeur.
+L'adresse de la table des pages est stockée dans un registre du processeur.
 L'utilisation de ce registre permet d'avoir une table des pages pour chaque processus.
 Pour cela il suffit qu'une zone de mémoire soit réservée pour chaque processus
 et que l'OS y stocke la table des pages du processus.
@@ -2144,20 +2144,20 @@ il faut éviter qu'un processus ne puisse modifier sa table des pages
 lui-même sans contrôle. Pour ce faire on utilise les bits de permissions.
 Un segment de code qui ne contient que des instructions sera par exemple
 stocké avec les bits \textit{R} et \textit{X} mais pas le bit \textit{W}.
-Le stack par contre sera placé dans des pages avec les bits \textit{R}
+Le stack ainsi que le heap seront placés dans des pages avec les bits \textit{R}
 et \textit{W} mais pas \textit{X}.
-Un accès interdit à une pages provoquera une segmentation fault.
+Un accès interdit à une page provoquera une segmentation fault.
 
-Les bits de permissions sont gérées par l'OS mais il peut parfois être utile de la modifier pour certaines pages. Cela se fait avec \texttt{\textbf{int} mprotect(\textbf{const void} *addr, \textbf{size\_t} len, \textbf{int} prot)} où \texttt{prot} peut prendre les valeurs \texttt{PROT\_NONE}, \texttt{PROT\_READ}, \texttt{PROT\_WRITE}, \texttt{PROT\_EXEC} ou une disjonction logique de ceux-ci. Si la protection demandé est plus \textit{faible} que celle actuelle, l'OS produira une segmentation fault.
+Les bits de permissions sont gérés par l'OS mais il peut parfois être utile de les modifier pour certaines pages. Cela se fait avec \texttt{\textbf{int} mprotect(\textbf{const void} *addr, \textbf{size\_t} len, \textbf{int} prot)} où \texttt{prot} peut prendre les valeurs \texttt{PROT\_NONE}, \texttt{PROT\_READ}, \texttt{PROT\_WRITE}, \texttt{PROT\_EXEC} ou une disjonction logique de ceux-ci. Si la protection demandée est plus \textit{faible} que l'actuelle, l'OS produira une segmentation fault.
 
-La traduction se fait comme suit
+La traduction se fait comme suit :
 
 \begin{enumerate}
   \item L'adresse virtuelle arrive au MMU, il regarde combien de bits de
-    points faibles on a
+    poids faible on a
     (si une page fait \si{4}{KiB}, ça fait $2^{12}$ bytes
-    donc 14 bits de points faibles.)
-    Les bits de point fort donnent l'indice dans la table des pages en binaire
+    donc 14 bits de poids faible.)
+    Les bits de poids fort donnent l'indice dans la table des pages en binaire
     (11001 signifie que c'est la 25ème entrée de la table des page).
   \item Le MMU regarde si la partie de la table des pages où il y a l'entrée
     25 est dans la TLB (sorte de cache pour la table des pages).
@@ -2181,13 +2181,13 @@ La traduction se fait comme suit
         il regarde s'il a les permissions, s'il ne les a pas segfault.
         Sinon, il ramène la page dans la RAM et met le dirty bit à false
         (pour dire que pour l'instant, la page est exactement pareil dans
-        la RAM que dans la swap donc si il faudra par la suite la remettre
+        la RAM que dans la swap donc s'il faudra par la suite la remettre
         dans la swap, il faudra même pas faire de copie)
         puis il met le bit de référence à true et s'il écrit,
         il met le dirty bit à true aussi.
     \end{itemize}
   \item Une fois qu'il a l'adresse physique de début de la page,
-    il ajoute à ça l'offset (les bits de point faibre de l'adresse virtuelle)
+    il ajoute à ça l'offset (les bits de poids faible de l'adresse virtuelle)
     et il a l'adresse physique exacte :)
 \end{enumerate}
 
@@ -2215,12 +2215,12 @@ Il ne faut pas confondre ça avec \lstinline{mmap}
 \end{itemize}
 
 \subsubsection{Mémoire partagée}
-Il est possible qu'une même page en mémoire physique soit utilisé par plusieurs processus différents. Par exemple dans le cas des threads (crées par l'OS), lorsqu'on crée un thread, on initialise sa table de page en copiant toutes les valeurs de son "père" mis à part celle qui correspond au stack. De cette manière le thread a accès au même variable global, segment text,... \\
+Il est possible qu'une même page en mémoire physique soit utilisée par plusieurs processus différents. Par exemple dans le cas des threads (créés par l'OS), lorsqu'on crée un thread, on initialise sa table de page en copiant toutes les valeurs de son "père" mis à part cellent qui correspondent au stack. De cette manière le thread a accès aux même variables globales, segment text,... \\
 
-En utilisant la table des pages intelligemment il est également possible de permettre à deux processus distincts d'avoir accès à la même zone mémoire physique. Ce qui leurs permettra de communiquer plus efficacement qu'avec des pipes par exemple. Cette technique porte le nom de \textit{\textbf{mémoire partagée}}. Pour ce faire 2 technique existent :
+En utilisant la table des pages intelligemment il est également possible de permettre à deux processus distincts d'avoir accès à la même zone mémoire physique. Ce qui leurs permettra de communiquer plus efficacement qu'avec des pipes par exemple. Cette technique porte le nom de \textit{\textbf{mémoire partagée}}. Pour ce faire 2 techniques existent :
 \begin{itemize}
   \item L'OS copie la table des pages du processus $P1$ dans la table des pages de $P2$.
-  \item L'OS créer une nouvelle page pouvant être partagée. Elle appartient au noyau mais est accessible à $P1$ et $P2$ en modifiant leur table des pages. \\
+  \item L'OS crée une nouvelle page pouvant être partagée. Elle appartient au noyau mais est accessible à $P1$ et $P2$ en modifiant leur table des pages. \\
     Avantages : meilleur contrôle possible par l'OS + peut vivre après la terminaison d'un processus.
 \end{itemize}
 Linux utilise la 2e solution. La mémoire partagée peut y être utilisée avec les appels système \texttt{shmget} (pour créer ou vérifier l'accès), \texttt{shmat} (pour ajouter la mémoire à la table des pages) et \texttt{shmdt} (pour détacher un segment de mémoire).\\
@@ -2232,24 +2232,24 @@ Linux utilise la 2e solution. La mémoire partagée peut y être utilisée avec 
 \end{wrapfigure}
 Il faut faire attention au pointeur en mémoire partagé ! En pratique, il ne vaut mieux pas les utiliser...\\
 
-Les segments de mémoire partagée sont gérés par le noyau, ils persistent donc après la terminaison du processus qui les a crée. Le nombre de segments partagés est limité. Il ne faut donc pas qu'il y en ai qui restent alors qu'ils ne sont plus utilisé. Il est possible de supprimer un segment partagé en utilisant l'appel système \texttt{shmctl}. En pratique, le noyau détruit un segment de mémoire partagée uniquement lorsqu'il n'y a plus de processus qui y sont attachés. On peut donc faire cette suppression juste après \texttt{shmat} de manière à être sûr que le segment sera supprimé si plus aucun processus n'est actif dessus (utilisable par exemple si on utilise la mémoire partagée pour communiquer entre un processus père et un fils).
+Les segments de mémoire partagée sont gérés par le noyau, ils persistent donc après la terminaison du processus qui les a créé. Le nombre de segments partagés est limité. Il ne faut donc pas qu'il y en ai qui restent alors qu'ils ne sont plus utilisé. Il est possible de supprimer un segment partagé en utilisant l'appel système \texttt{shmctl}. En pratique, le noyau détruit un segment de mémoire partagée uniquement lorsqu'il n'y a plus de processus qui y sont attachés. On peut donc faire cette suppression juste après \texttt{shmat} de manière à être sûr que le segment sera supprimé si plus aucun processus n'est actif dessus (utilisable par exemple si on utilise la mémoire partagée pour communiquer entre un processus père et un fils).
 
 
 \subsubsection{Implémentation de fork}
-Afin d'optimiser le fonctionnement de fork, il n'y a pas de réelle copie des pages du processus père. En réalité le système utilise \textit{copy-on-write}. Le noyau copie toutes les entrées de la table des pages du processus père vert la table des pages du processus fils et les marque d'un bit $p$ pour indiquer qu'elles sont en \texttt{copy-on-write}.  Si un processus tente un accès en écriture sur une de ces pages, le MMU interrompt l'exécution du processus et force l'exécution d'une routine d'interruption du noyau. Si le processus a effectivement les autorisation d'écriture, le noyau alloue une nouvelle page physique et y recopie la page  où la tentative a eu lieu. La table des pages est mises à jour et le processus peut continuer. Cette technique de \textit{\textbf{copy-on-write}} permet de ne copier que les pages qui sont effectivement modifiées par le processus père ou le processus fils.
+Afin d'optimiser le fonctionnement de fork, il n'y a pas de réelle copie des pages du processus père. En réalité le système utilise \textit{copy-on-write}. Le noyau copie toutes les entrées de la table des pages du processus père vert la table des pages du processus fils et les marque d'un bit $p$ pour indiquer qu'elles sont en \texttt{copy-on-write}.  Si un processus tente un accès en écriture sur une de ces pages, le MMU interrompt l'exécution du processus et force l'exécution d'une routine d'interruption du noyau. Si le processus a effectivement les autorisations d'écriture, le noyau alloue une nouvelle page physique et y recopie la page où la tentative a eu lieu. La table des pages est mise à jour et le processus peut continuer. Cette technique de \textit{\textbf{copy-on-write}} permet de ne copier que les pages qui sont effectivement modifiées par le processus père ou le processus fils.
 \subsection{Fichiers mappés en mémoire}
 \begin{figure}[!h]
   \centering \includegraphics[width=0.7\textwidth]{mmap}
   \caption{\label{fig:mmap}Fichier mappés en mémoire}
 \end{figure}
-Grâce à la mémoire virtuelle il est possible de placer le contenu d'un fichier ou une partie dans une zone de mémoire du processus. Cette opération peut être effectuée en utilisant l'appel système \texttt{mmap}. \texttt{mmap} prend entre autre un argument qui spécifie si les pages du fichier sont mappées dans chaque processus (avec \texttt{MAP\_PRIVATE} dans ce cas une écriture n'est pas répercuté sur les autres processus) ou si plusieurs processus peuvent accéder et modifier la page (avec \texttt{MAP\_SHARED}). Les changements fait sur un fichier mappés ne sont pas immédiatement fait dans le fichier sur le dispositif de stockage. On peut utiliser \texttt{msync} permet de demander cette écriture doit être faite (avec le drapeau \texttt{MS\_SINC} il attend la fin, tandis qu'avec \texttt{MS\_ASYNc} il ne fait que démarrer l'écriture). \\
+Grâce à la mémoire virtuelle il est possible de placer le contenu d'un fichier ou une partie dans une zone de mémoire du processus. Cette opération peut être effectuée en utilisant l'appel système \texttt{mmap}. \texttt{mmap} prend entre autre un argument qui spécifie si les pages du fichier sont mappées dans chaque processus (avec \texttt{MAP\_PRIVATE} dans ce cas une écriture n'est pas répercuté sur les autres processus) ou si plusieurs processus peuvent accéder et modifier la page (avec \texttt{MAP\_SHARED}). Les changements fait sur un fichier mappés ne sont pas immédiatement fait dans le fichier sur le dispositif de stockage. On peut utiliser \texttt{msync} qui permet de demander si cette écriture doit être faite (avec le drapeau \texttt{MS\_SINC} il attend la fin, tandis qu'avec \texttt{MS\_ASYNc} il ne fait que démarrer l'écriture). \\
 À la fin de l'utilisation, d'un fichier mappé, le processus doit appeler l'appel système \texttt{munmap}.
 \subsection{Utilisation des dispositifs de stockage}
-Comme nous l'avions vu plus haut, les pages peuvent ne pas se trouver en mémoire RAM. Dans ce cas, soit elles n'existe plus, soit elles sont stockée sur un dispositif de stockage. Sous Linux on utilise une partition \textit{swap} pour stocké les pages qui ne sont pas en mémoire RAM. Le fonctionnement de la mémoire virtuel peut alors être vu de la façon suivante : le \textit{MMU} est intérgré directement sur le processeur et comprend un \textit{TLB} (\textit{Translation Lookaside Buffer}) qui sert de cache pour les entrées de la table des pages du processus qui est en train de s'exécuter. Si la page demandé ne se trouve pas en mémoire RAM, il s'occupera de la rapatrié (ce qui peut prendre quelque dizaine de millisecondes). Tant que cette page n'est pas disponible en mémoire RAM, le processus est mis à l'état bloqué et l'OS effectue un changement de contexte pour exécuter un autre processus.
+Comme nous l'avions vu plus haut, les pages peuvent ne pas se trouver en mémoire RAM. Dans ce cas, soit elles n'existent plus, soit elles sont stockées sur un dispositif de stockage. Sous Linux on utilise une partition \textit{swap} pour stocker les pages qui ne sont pas en mémoire RAM. Le fonctionnement de la mémoire virtuelle peut alors être vu de la façon suivante : le \textit{MMU} est intérgré directement sur le processeur et comprend un \textit{TLB} (\textit{Translation Lookaside Buffer}) qui sert de cache pour les entrées de la table des pages du processus qui est en train de s'exécuter. Si la page demandée ne se trouve pas en mémoire RAM, il s'occupera de la rapatrier (ce qui peut prendre quelques dizaines de millisecondes). Tant que cette page n'est pas disponible en mémoire RAM, le processus est mis à l'état bloqué et l'OS effectue un changement de contexte pour exécuter un autre processus.
 \subsection{Stratégie de remplacement de pages}
-C'est l'OS qui prend en charge le transferts des pages entre les dispositifs de stockage et la mémoire. Tant que la RAM n'est pas remplie, il suffit de ramener une ou plusieurs pages du dispositif de stockage vers la mémoire RAM.  En général, l'OS utilisera le principe de localité. Par contre si la mémoire RAM est pleine, il faut une stratégie de remplacement des pages.
+C'est l'OS qui prend en charge le transfert des pages entre les dispositifs de stockage et la mémoire. Tant que la RAM n'est pas remplie, il suffit de ramener une ou plusieurs pages du dispositif de stockage vers la mémoire RAM.  En général, l'OS utilisera le principe de localité. Par contre si la mémoire RAM est pleine, il faut une stratégie de remplacement des pages.
 
-Une première stratégie de remplacement de pages pourrait être de sauvegarder les identifiants des pages dans une file \textit{FIFO}. C'est facile à implémenter mais les premières pages arrivées ne sont pas spécialement les moins utilisée.
+Une première stratégie de remplacement de pages pourrait être de sauvegarder les identifiants des pages dans une file \textit{FIFO}. C'est facile à implémenter mais les premières pages arrivées ne sont pas spécialement les moins utilisées.
 
 Une autre stratégie serait de maintenir les statistiques d'utilisation de chaque page afin de prédire les pages qui seront nécessaires dans le futur. Mais cette stratégie nécessiterait que le \textit{TLB} mette à jour les statistique à chaque accès à une page : difficile, et pas performant.
 
@@ -2274,20 +2274,20 @@ L'algorithme de remplacement peut alors classé les pages en 4 catégories :
     \textbf{bit de} & \multirow{2}*{\textbf{dirty bit}} & \multirow{2}*{\textbf{Signification}} \\
     \textbf{référence} & & \\
     \hline
-    FAUX & FAUX & N'ont pas été utilisées récemment et sont identique à la version déjà sur disque. \\
+    FAUX & FAUX & N'ont pas été utilisées récemment et sont identiques à la version déjà sur disque. \\
     \hline
-    FAUX & VRAI & N'ont pas été utilisées récemment mais doivent être mises a jour sur disque. \\
+    FAUX & VRAI & N'ont pas été utilisées récemment mais doivent être mises à jour sur disque. \\
     \hline
-    VRAI & FAUX & Ont été utilisées récemment mais ne doivent pas être mise à jour sur disque. \\
+    VRAI & FAUX & Ont été utilisées récemment mais ne doivent pas être mises à jour sur disque. \\
     \hline
-    VRAI & VRAI & Ont été utilisées récemment et doivent être mise à jour sur disque. \\
+    VRAI & VRAI & Ont été utilisées récemment et doivent être mises à jour sur disque. \\
     \hline
   \end{tabular}
 \end{center}
 
 
 \subsection{Interactions entre le processus et la mémoire}
-Linux comprend plusieurs appels systèmes qui permettent à un processus d'influencer la stratégie de remplacement du noyau. C'est par exemple utilisé par les applications de cryptographies pour éviter qu'une clé en mémoire ne soit sauvegardée sur un disque dur.  L'appel système \texttt{mlock} et \texttt{munlock} peut être utilisé pour ce faire. Il faut néanmoins être vigilant avec ces appels systèmes et en pratique il ne seront utilisé que pour les applications cryptographiques et les processus avec des exigences temps réel.
+Linux comprend plusieurs appels systèmes qui permettent à un processus d'influencer la stratégie de remplacement du noyau. C'est par exemple utilisé par les applications de cryptographies pour éviter qu'une clé en mémoire ne soit sauvegardée sur un disque dur.  L'appel système \texttt{mlock} et \texttt{munlock} peut être utilisé pour ce faire. Il faut néanmoins être vigilant avec ces appels systèmes et en pratique ils ne seront utilisés que pour les applications cryptographiques et les processus avec des exigences temps réel.
 
 \subsection{\texttt{execve} et la mémoire virtuelle}
 \texttt{execve} utilisera un fichier mappé en écriture pour les instructions de l'exécutable et un fichier mappé accessible en lecture/écriture pour les zones des chaînes de caractère et les variables. Ce dernier sera en \textit{copy-on-write}.

--- a/src/q4/os-SINF1225/summary/os-SINF1225-summary.tex
+++ b/src/q4/os-SINF1225/summary/os-SINF1225-summary.tex
@@ -2274,13 +2274,17 @@ L'algorithme de remplacement peut alors classé les pages en 4 catégories :
     \textbf{bit de} & \multirow{2}*{\textbf{dirty bit}} & \multirow{2}*{\textbf{Signification}} \\
     \textbf{référence} & & \\
     \hline
-    FAUX & FAUX & N'ont pas été utilisées récemment et sont identiques à la version déjà sur disque. \\
+    \multirow{2}*{FAUX} & \multirow{2}*{FAUX} & N'ont pas été utilisées récemment \\
+    & & et sont identiques à la version déjà sur disque.\\
     \hline
-    FAUX & VRAI & N'ont pas été utilisées récemment mais doivent être mises à jour sur disque. \\
+    \multirow{2}*{FAUX} & \multirow{2}*{VRAI} & N'ont pas été utilisées récemment\\
+    & & mais doivent être mises à jour sur disque. \\
     \hline
-    VRAI & FAUX & Ont été utilisées récemment mais ne doivent pas être mises à jour sur disque. \\
+    \multirow{2}*{VRAI} & \multirow{2}*{FAUX} & Ont été utilisées récemment \\
+    & &  mais ne doivent pas être mises à jour sur disque.\\
     \hline
-    VRAI & VRAI & Ont été utilisées récemment et doivent être mises à jour sur disque. \\
+    \multirow{2}*{VRAI} & \multirow{2}*{VRAI} & Ont été utilisées récemment \\
+    & & et doivent être mises à jour sur disque.\\
     \hline
   \end{tabular}
 \end{center}

--- a/src/q4/os-SINF1225/summary/os-SINF1225-summary.tex
+++ b/src/q4/os-SINF1225/summary/os-SINF1225-summary.tex
@@ -383,7 +383,7 @@ Par contre  si la fonction essaye de changer le pointeur lui même (pour qu'il p
 \subsection{Manipulation de bits}
 Le langage C permet au programmeur de manipuler facilement les bits qui se trouves en mémoire.
 Pour cela, le langage C définit des expressions qui correspondent à la plupart des opérations de manipulation de bits que l'on retrouve dans les langages d'assemblage.
-Les premières opérations sont les opérations logiques, elles sont résumé par le tableau \ref{table:opbin}.
+Les premières opérations sont les opérations logiques, elles sont résumées par le tableau \ref{table:opbin}.
 
 \begin{table}[!h]
   \begin{center}
@@ -529,7 +529,7 @@ En C, une variable a une \textbf{portée globale} lorsqu'elle est définie en de
 Une telle variable est accessible dans toutes les fonctions présentes dans le fichier.
 Dans un fichier donné, il ne peut donc évidemment pas y avoir deux variables globales qui ont le même identifiant.
 Une variable définie dans un \textbf{bloc} a par contre une \textbf{portée locale} à ce bloc.
-La variable n'existe pas avnt le début du bloc et n'existe plus à la fin du bloc.
+La variable n'existe pas avant le début du bloc et n'existe plus à la fin du bloc.
 
 Lorsqu'un identifiant de variable locale est utilisé à plusieurs endroits dans un fichier, c'est la définition la plus proche qui est utilisée.
 
@@ -760,10 +760,10 @@ Ainsi, un processeur qui utilise des adresses sur 32 bits n'est pas capable phys
   \caption{\label{fig:vanNeumann}Architecture d'un ordinateur actuel}
 \end{wrapfigure}
 \paragraph{Approche complexe} En pratique, l'organisation d'un ordinateur actuel est plus complexe que le modèle de von Neumann.
-La figure \ref{fig:mem2} présente de manière schématique l'organisation actuelle d'un ordinateur.
+La figure \ref{fig:vanNeumann} présente de manière schématique l'organisation actuelle d'un ordinateur.
 
 Le processeur est directement connecté à la mémoire via un \textbf{\textit{bus}} de communication rapide permettant des échanges de données et d'instructions efficaces entre la mémoire et le processeur.
-En plus du proesseur et de la mémoire, un 3e dispositif, souvent appelé \textit{adaptateur de bus} est connecté au bus processeur-mémoire.
+En plus du processeur et de la mémoire, un 3e dispositif, souvent appelé \textit{adaptateur de bus} est connecté au bus processeur-mémoire.
 Cet adaptateur permet au processeur d'accéder aux dispositifs de stockage ou aux dispositifs d'entrées-sorties tels que le clavier, la souris ou les cartes réseau.
 En pratique, cela se réalise en connectant les différents dispositifs à un autre bus de communication (PCI, SCSI,...) et en utilisant un adaptateur de bus qui est capable de traduire les commandes venant du processeur.
 
@@ -1266,7 +1266,7 @@ Cette loi fixe une limite théorique difficile à atteindre et suppose que la pa
 Le première façon pour un processus de communiquer des infos avec un thread qu'il a lancé est d'utiliser les arguments de la fonction de démarrage du thread et la valeur retournée par ce thread.
 Mais c'est un canal de communication très limité qui ne permet pas d'échange d'information pendant l'exécution du thread.
 
-Un processus peut partager facilement de l'information avec ses threads ou même entre plusieurs threads car tout les threads ont accès aux mêmes variables globales et au même heap.
+Un processus peut partager facilement de l'information avec ses threads ou même entre plusieurs threads car tous les threads ont accès aux mêmes variables globales et au même heap.
 Malheureusement la modification d'une variable globale ou d'une zone mémoire (allouée par malloc) peut être source de problèmes si plusieurs threads accède à la même donnée en même temps.\\
 Ce problème d'accès à une même donnée est connu sous le nom de problème de la \emph{section critique} ou \emph{exclusion mutuelle}.
 La \emph{section critique} peut être définie comme étant une séquence d'instructions qui ne peuvent jamais être exécutées par plusieurs threads simultanément.
@@ -1312,7 +1312,7 @@ Sur un système Unix, il y a 2 types d'événements qui peuvent provoquer un cha
 
 \paragraph{Interruption : } Une interruption est un signal électronique qui est généré par un dispositifs connectés au microprocesseur. De nombreux dispositifs d'entrées-sorties comme les cartes réseau ou les contrôleurs de disque peuvent générer une interruption lorsqu'une information a été lue ou reçue et doit être traitée par le processeur.
 En outre, chaque ordinateur dispose d'une horloge temps réel qui génère des interruptions à une fréquence déterminée par l'OS (entre quelques dizaines et quelques milliers de Hz).
-Ces interruptions nécessitent un traitement rapide de la part de l'OS : C'est pourquoi le processeur vérifie, à la fin de l'exécution de \textit{chaque} instruction si un signal d'interruption est présent\footnote{Le cours se limite à un seul type de signa d'interruption}.Si c'est le cas, le processeur sauvegarde en mémoire le contexte du thread en cours d'exécution et lance une routine de traitement d'interruption faisant partie du système d'exploitation.
+Ces interruptions nécessitent un traitement rapide de la part de l'OS : C'est pourquoi le processeur vérifie, à la fin de l'exécution de \textit{chaque} instruction si un signal d'interruption est présent\footnote{Le cours se limite à un seul type de signal d'interruption}.Si c'est le cas, le processeur sauvegarde en mémoire le contexte du thread en cours d'exécution et lance une routine de traitement d'interruption faisant partie du système d'exploitation.
 
 \paragraph{Appel système :} Un thread exécute un appel système chaque fois qu'il doit intéragir avec l'OS.
 Ces appels peuvent être exécutés directement ou via une fonction de la librairie\footnote{La section \texttt{2} du manuel décrits les appels systèmes, la section \texttt{3} décrit les fonctions de la librairie.}.
@@ -1327,7 +1327,7 @@ Ces appels peuvent être exécutés directement ou via une fonction de la librai
 \end{itemize}
 
 La figure \ref{fig:appelsbloquant} représente les différents état d'un thread.
-Lorsqu'un thread est crée (avec \texttt{pthread\_create}), il est placé dans l'état \textit{Ready}. \\
+Lorsqu'un thread est créé (avec \texttt{pthread\_create}), il est placé dans l'état \textit{Ready}. \\
 \begin{wrapfigure}{r}{0.45\textwidth}
   \vspace{-0.5cm}
   \includegraphics[width=0.55\textwidth]{appelsbloquant}
@@ -1367,7 +1367,7 @@ Conclusion : Ce n'est pas un mécanisme utilisable\footnote{Bien que ce soit par
 
 \subsubsection*{L'algorithme de Peterson}
 Cette solution permet à plusieurs threads de coordonner leur exécution de façon à éviter une violation de section critique en utilisant uniquement des variables accessibles à tous les threads.
-La solution est applicable à $N$ thread mais nous nous limiterons à 2 threads.
+La solution est applicable à $N$ threads mais nous nous limiterons à 2 threads.
 
 \begin{lstlisting}
 #define A 0
@@ -1410,7 +1410,7 @@ Sur les ordinateurs actuels, il est difficile d'utiliser l'algorithme de Peterso
 \end{itemize}
 Pour résoudre ce problème, les architectes de microprocesseurs ont proposé l'utilisation d'opérations atomiques.
 Une \textbf{opération atomique} est une opération qui lorsqu'elle est exécutée sur un processeur ne peut pas être interrompue par l'arrivée d'une interruption.
-De plus, l'exécution d'une instruction atomique par un ou plusieurs processeur implique une coordination des processeurs pour l'accès à la zone mémoire référencée dans l'instruction.
+De plus, l'exécution d'une instruction atomique par un ou plusieurs processeurs implique une coordination des processeurs pour l'accès à la zone mémoire référencée dans l'instruction.
 Via un mécanisme qui sort du cadre de ce cours, tous les accès à la mémoire faits par les instruction atomique sont réalisés séquentiellement. \\
 \\
 Considérons l'instruction \texttt{xchg} supportée par les processeur IA32.
@@ -1478,8 +1478,8 @@ La propriété de vivacité est respecté si chaque thread exécute \texttt{pthr
   \includegraphics[width=0.2\textwidth]{philosophes}
   \caption{\label{fig:philosophes}Problème des philosophes}
 \end{wrapfigure}
-Le problème des philosophe est résumé sur la figure \ref{fig:philosophes}.
-Chacun veut saisir la baguette de droite et de gauche qui sont chacune partagée avec (respectivement) son voisin de gauche et de droite.
+Le problème des philosophes est résumé sur la figure \ref{fig:philosophes}.
+Chacun veut saisir la baguette de droite et de gauche qui sont chacune partagées avec (respectivement) son voisin de gauche et de droite.
 
 Le problème est que si tout le monde commence par prendre la baguette de gauche, il n'y a plus de baguette de droite disponible (puisqu'elle est à gauche de votre voisin de droite) et donc on se trouve dans une impasse.
 Il s'agit d'un \textbf{\textit{deadlock}}.
@@ -1516,7 +1516,7 @@ void* philosophe ( void* arg )
 \end{lstlisting}
 
 
-Ce problème des philosophe est à l'origine de la règle de bonne pratique suivante : Pour éviter les deadlocks, il est nécessaire d'ordonnancer tous les mutex utilisés par le programme dans un ordre struct.
+Ce problème des philosophes est à l'origine de la règle de bonne pratique suivante : Pour éviter les deadlocks, il est nécessaire d'ordonnancer tous les mutex utilisés par le programme dans un ordre strict.
 Lorsqu'un thread doit réserver plusieurs  mutex en même temps, il doit \textit{toujours} effectuer ses appels à \texttt{pthread\_mutex\_lock} dans l'ordre choisi pour les mutex.
 (Sinon deadlock possible).
 
@@ -1550,8 +1550,8 @@ Pour les mutex, certaines implémentations supposent que c'est le même thread q
 Lorsque ces opérations doivent être effectuées dans des threads différents,e il est donc préférable d'utiliser des sémaphores à la place des mutex.
 
 \paragraph{Problème du rendez-vous}~\\
-Ce problème est rencontré lorsqu'une application découpé en $N$ thread doit attendre la fin de l'exécution d'une première phase dans les $N$ threads avant de pouvoir passer à la suite.
-Chaque thread peut être résumé par une 1e phase, suivit d'un endroit de "rendez-vous" pour tous les threads et d'une deuxième phase.
+Ce problème est rencontré lorsqu'une application découpée en $N$ threads doit attendre la fin de l'exécution d'une première phase dans les $N$ threads avant de pouvoir passer à la suite.
+Chaque thread peut être résumé par une première phase, suivit d'un endroit de "rendez-vous" pour tous les threads et d'une deuxième phase.
 La solution est la suivante :
 \begin{lstlisting}
 premiere_phase();
@@ -1769,11 +1769,11 @@ Considérons par exemple un utilisateur qui exécute la commande \texttt{/usr/bi
   \item \texttt{>0} pour le processus père. Cette valeur correspond à l'identifiant du processus fils crée.
   \item \texttt{-1} en cas d'erreur. Dans ce cas, \texttt{errno} est mis à jour.
 \end{itemize}
-Contrairement au thread, les données en mémoires sont toutes copiée et donc même la modification d'une variable globale ou d'une zone mémoire n'aura aucun impact sur l'autre processus. (Pour connaître les moyens de communication entre processus, voir la section \ref{communicationproc} à la page \ref{communicationproc}). \\
+Contrairement au thread, les données en mémoires sont toutes copiées et donc même la modification d'une variable globale ou d'une zone mémoire n'aura aucun impact sur l'autre processus. (Pour connaître les moyens de communication entre processus, voir la section \ref{communicationproc} à la page \ref{communicationproc}). \\
 
-Le kernel gère les processus et attribue un identifiant (de type \texttt{pid\_t} sous Unix) à chaque processus. L'appel système \texttt{gitpid} permet de récupérer l'identifiant du processus courant tandis que \texttt{getppid} permet de récupérer l'identifiant du processus père. \\
+Le kernel gère les processus et attribue un identifiant (de type \texttt{pid\_t} sous Unix) à chaque processus. L'appel système \texttt{getpid} permet de récupérer l'identifiant du processus courant tandis que \texttt{getppid} permet de récupérer l'identifiant du processus père. \\
 
-Après l'appel de \texttt{fork}, les 2 processus partagent certaines ressources qui sont gérée par le kernel. Notamment \textit{stdin}, \textit{stdout} et \textit{stderr}. Il faut donc que des précaution soit prise afin que les écritures sur la sorties standard s'affiche correctement (par exemple). En réalité les fonctions telles que \texttt{printf} et \texttt{putchar} de la librairie standard utilisent l'appel système \texttt{write} qui est le seul permettant d'écrire sur un flux tel que \textit{stdout}. L'utilisation à outrance de cet appel système est coûteux pour les performance d'une application, c'est pourquoi, la librairie standard utilise un buffer dans laquelle elle stocke temporairement les données avant de les écrire en une fois via \texttt{write}\footnote{Ce buffer peut être contrôlé avec \texttt{setvbuff} et \texttt{setbuf}. Par exemple pour le désactiver : \texttt{setbuf(stdout, NULL}}. Il est possible de "vider"\footnote{C'est à dire de forcer l'écriture sur le flux concerné.} immédiatement le buffer en utilisant la fonction \texttt{\textbf{int} fflush(\textbf{FILE} *stream)}.
+Après l'appel de \texttt{fork}, les 2 processus partagent certaines ressources qui sont gérée par le kernel. Notamment \textit{stdin}, \textit{stdout} et \textit{stderr}. Il faut donc que des précaution soit prise afin que les écritures sur la sorties standard s'affiche correctement (par exemple). En réalité les fonctions telles que \texttt{printf} et \texttt{putchar} de la librairie standard utilisent l'appel système \texttt{write} qui est le seul permettant d'écrire sur un flux tel que \textit{stdout}. L'utilisation à outrance de cet appel système est coûteux pour les performances d'une application, c'est pourquoi, la librairie standard utilise un buffer dans laquelle elle stocke temporairement les données avant de les écrire en une fois via \texttt{write}\footnote{Ce buffer peut être contrôlé avec \texttt{setvbuff} et \texttt{setbuf}. Par exemple pour le désactiver : \texttt{setbuf(stdout, NULL}}. Il est possible de "vider"\footnote{C'est à dire de forcer l'écriture sur le flux concerné.} immédiatement le buffer en utilisant la fonction \texttt{\textbf{int} fflush(\textbf{FILE} *stream)}.
 
 \subsection{Fin d'un processus}
 Comme nous l'avons déjà vu, un programme C peut se terminer de 2 façons :
@@ -1789,7 +1789,7 @@ Lorsque le père se termine avant le processus fils, le processus fils est dit \
 \subsection{Exécution d'un programme}
 Pour exécuter un programme, il existe l'appel système \texttt{execve}. Celui-ci remplace l'image en mémoire du processus par l'image de l'exécutable passé en argument, et son exécution démarre à la fonction \texttt{main} de ce dernier.\\
 \texttt{\textbf{int} execve(\textbf{const} \textbf{char} *path, \textbf{char} *\textbf{const} argv[], \textbf{char} *\textbf{const} envp[]);}\\
-\texttt{execve} ne retourne un valeur de retour que en cas d'échec, en effet dans le cas contraire, tout ce qui se trouve après \texttt{execve} ne sera pas exécuté puisque tout est remplacé par le nouveau programme. Dans le cas d'un processus ayant lancé des threads, ceux-ci seraient automatiquement supprimé puisque c'est toute l'image qui est remplacée. Par contre pour les flux standard (\textit{stdout},..), il est préférable de forcer leur écriture avec \texttt{fflush} car ce n'est pas fait automatiquement.\\
+\texttt{execve} ne retourne une valeur de retour que en cas d'échec, en effet dans le cas contraire, tout ce qui se trouve après \texttt{execve} ne sera pas exécuté puisque tout est remplacé par le nouveau programme. Dans le cas d'un processus ayant lancé des threads, ceux-ci seraient automatiquement supprimé puisque c'est toute l'image qui est remplacée. Par contre pour les flux standard (\textit{stdout},..), il est préférable de forcer leur écriture avec \texttt{fflush} car ce n'est pas fait automatiquement.\\
 
 Les valeurs retourné par un processus fils sont stockée sur 8 bits, la plus grande valeur positive est donc 127 (utilisé en cas d'erreur ?). \\
 
@@ -1806,7 +1806,7 @@ Voyons comment \texttt{execve} fonctionne :
     \begin{enumerate}[a)]
       \item Soit il s'agit d'un fichier directement exécutable.
         Sous les systèmes Linux actuels, ce fichier sera au format \texttt{elf}
-        et début par une entête qui contient une chaîne de caractère
+        et débute par une entête qui contient une chaîne de caractère
         utilisée comme marqueur ou chaîne magique.
       \item Soit le fichier est en langage interprété et débute alors par \texttt{\#!} suivit du nom complet de l'interpréteur à utiliser et de ses paramètres éventuels à utiliser.
     \end{enumerate}
@@ -1814,7 +1814,7 @@ Voyons comment \texttt{execve} fonctionne :
 En pratique, on peut définir n'importe quel interpréteur (et en créer), il suffit qu'il s'agisse d'un exécutable. Celui-ci recevra le texte du fichier à interpréter. Cette facilité d'ajouter de nouveaux interpréteur de commande est une des forces des OS de la famille Unix.
 
 \subsection{Table des processus}
-Un OS tel que Linux maintient certaines infos à propos de chaque processus dans une \textbf{\textit{table de processus}}. Ces infos peuvent être obtenue via \texttt{ps}, \texttt{top},\texttt{pstree},... En fait tout ces utilitaire utilisent les informations contenue dans le répertoire \texttt{/proc}. Ce répertoire contient plusieurs entrée (fichiers et répertoires). Citons le répertoire \texttt{/proc/\textit{pid}/} où \texttt{\textit{pid}} est l'identifiant du processus. Ce répertoire contient notamment :
+Un OS tel que Linux maintient certaines infos à propos de chaque processus dans une \textbf{\textit{table de processus}}. Ces infos peuvent être obtenues via \texttt{ps}, \texttt{top},\texttt{pstree},... En fait tous ces utilitaires utilisent les informations contenues dans le répertoire \texttt{/proc}. Ce répertoire contient plusieurs entrées (fichiers et répertoires). Citons le répertoire \texttt{/proc/\textit{pid}/} où \texttt{\textit{pid}} est l'identifiant du processus. Ce répertoire contient notamment :
 \begin{itemize}
   \item \texttt{cmdline} : Ligne de commande de lancement
   \item \texttt{environ} : Variables d'environnements
@@ -1874,14 +1874,14 @@ L'OS prévoit par défaut le traitement de tous les signaux, mais il est possibl
 \textbf{sighandler\_t} signal(\textbf{int} signum, \textbf{sighandler\_t} handler);}\\
 Pour spécifié le traitement par défaut on utilise \texttt{SIG\_DFL} en argument, en pour ignorer le signal \texttt{SIG\_IGN}. \texttt{signal} renvoit l'ancienne \textit{handler} utilisée ou \texttt{SIG\_ERR} en cas d'erreur.\\
 
-Il faut être attentif à ce que la fonction handler puisse bien s'exécuter à n'importe quel moment de l'exécution (alors que d'autres instructions était en cours d'exécution). Il n'est cependant pas possible d'utiliser les mutex pour les signaux car il faut que le traitement du signal soit terminé pour qu'on puisse retourné à la fonction dans laquelle on se trouvait. Il est important de déclarer les variables globale utilisé par la gestion du signal comme étant \texttt{volatile} afin de forcer à recharger la valeur avant chaque utilisation. Mais cela ne suffit pas car un signal peut interrompre le processus juste après qu'il ait rechargé la valeur et juste avant qu'il ne l'utilise. C'est pourquoi il est préférable de n'utiliser que des variables du type \texttt{sig\_atomic\_t} qui garantit que les accès se feront de manière atomique. Il faut également être attentif à ne pas utiliser des fonctions de la librairies standard qui pourrait interférer avec elles même si elles sont en cours d'utilisation par le processus principal (par exemple si le handler modifie \texttt{errno}, alors qu'on l'utilise déjà). \\
+Il faut être attentif à ce que la fonction handler puisse bien s'exécuter à n'importe quel moment de l'exécution (alors que d'autres instructions étaient en cours d'exécution). Il n'est cependant pas possible d'utiliser les mutex pour les signaux car il faut que le traitement du signal soit terminé pour qu'on puisse retourner à la fonction dans laquelle on se trouvait. Il est important de déclarer les variables globales utilisées par la gestion du signal comme étant \texttt{volatile} afin de forcer à recharger la valeur avant chaque utilisation. Mais cela ne suffit pas car un signal peut interrompre le processus juste après qu'il ait rechargé la valeur et juste avant qu'il ne l'utilise. C'est pourquoi il est préférable de n'utiliser que des variables du type \texttt{sig\_atomic\_t} qui garantit que les accès se feront de manière atomique. Il faut également être attentif à ne pas utiliser des fonctions de la librairies standard qui pourrait interférer avec elles même si elles sont en cours d'utilisation par le processus principal (par exemple si le handler modifie \texttt{errno}, alors qu'on l'utilise déjà). \\
 
 Pour le traitement des signaux par un OS, il y a 2 stratégies :
 \begin{itemize}
-  \item Considérer qu'un signal est un message envoyé par la noyau ou un processus à un autre processus. Le noyau contient une queue qui stocke tous les signaux destinés à un processus donné. Chaque fois que le noyau réactive une processus, il vérifie si la queue associé contient un ou plusieurs messages concernant des signaux, si c'est le cas il appel la fonction de traitement du signal.\\
-    Avantage : Tout les signaux sont reçu.\\
+  \item Considérer qu'un signal est un message envoyé par la noyau ou un processus à un autre processus. Le noyau contient une queue qui stocke tous les signaux destinés à un processus donné. Chaque fois que le noyau réactive uns processus, il vérifie si la queue associée contient un ou plusieurs messages concernant des signaux, si c'est le cas il appelle la fonction de traitement du signal.\\
+    Avantage : Tous les signaux sont reçus.\\
     Inconvénient : Il faut maintenir une queue de taille variable pour chaque processus.\\
-  \item Représenter l'ensemble des signaux qu'un processus peut recevoir sous la forme de drapeaux binaires (1 drapeau par signal). Avec cette stratégie, lors de l'envoi d'un signal, on modifie le drapeau correspondant sur le processus destination (sauf si ce processus ignore ce type de signal). Chaque fois que le noyau réactive un processus, il vérifie les drapeaux relatifs aux signaux du processus. Si un drapeau est vrai il appel la fonction de traitement correspondante. \\
+  \item Représenter l'ensemble des signaux qu'un processus peut recevoir sous la forme de drapeaux binaires (1 drapeau par signal). Avec cette stratégie, lors de l'envoi d'un signal, on modifie le drapeau correspondant sur le processus destination (sauf si ce processus ignore ce type de signal). Chaque fois que le noyau réactive un processus, il vérifie les drapeaux relatifs aux signaux du processus. Si un drapeau est vrai il appelle la fonction de traitement correspondante. \\
     Avantage : Il suffit d'un bit par signal. \\
     Inconvénient : Aucune garantie sur la délivrance des signaux. Le nombre de signaux reçu n'est pas fiable.
 \end{itemize}
@@ -1926,7 +1926,7 @@ static void sigfpe_handler(int signum){
 }
 \end{lstlisting}
 \subsubsection{Temporisateurs}
-Il est possible d'envoyer un signal après un certain temps en utilisant \texttt{setitimer} ou \texttt{alarm} afin d'arrêter un appels systèmes bloquant après un certain temps. Exemple (si on veut laisser que 5 seconde à l'utilisateur pour taper 1 caractère de réponse):
+Il est possible d'envoyer un signal après un certain temps en utilisant \texttt{setitimer} ou \texttt{alarm} afin d'arrêter un appels systèmes bloquant après un certain temps. Exemple (si on veut laisser que 5 secondes à l'utilisateur pour taper 1 caractère de réponse):
 \begin{lstlisting}
 ...
 if(signal(SIGALRM, sig_handler)==SIG_ERR)==SIG_ERR){ perror("signal"); exit(EXIT_FAILURE); }
@@ -1949,17 +1949,17 @@ static void sig_handler(int signum){
   // rien a faire, read sera interrompu
 }
 \end{lstlisting}
-Si le système est surchargé, il est possible qu'il y ait 5 secondes qui passe entre la ligne 8 et la ligne 9. Pour éviter ce problème il faudra donc faire appel à \texttt{siglongjmp} et \texttt{sigsetjmp} afin de savoir si un signal \texttt{SIGALRM} a déjà été reçu.
+Si le système est surchargé, il est possible qu'il y ait 5 secondes qui passent entre la ligne 8 et la ligne 9. Pour éviter ce problème il faudra donc faire appel à \texttt{siglongjmp} et \texttt{sigsetjmp} afin de savoir si un signal \texttt{SIGALRM} a déjà été reçu.
 \subsection{Sémaphores}
-Il n'est pas possible d'utiliser la fonction \texttt{sem\_init} vue de le cas des threads car les processus ne partagent pas nécessairement la même zone mémoire. Par contre, il est possible d'utilisé un sémaphore nommé. Un \textbf{\textit{sémaphore nommé}} est identifié par un \textit{nom}; sous Linux, il correspond à un fichier (dans le dossier virtuel \texttt{/dev/shm} et tout processus qui connaît le nom et a les autorisation d'y accéder peut l'utiliser. \\
+Il n'est pas possible d'utiliser la fonction \texttt{sem\_init} vue de le cas des threads car les processus ne partagent pas nécessairement la même zone mémoire. Par contre, il est possible d'utilisé un sémaphore nommé. Un \textbf{\textit{sémaphore nommé}} est identifié par un \textit{nom}; sous Linux, il correspond à un fichier (dans le dossier virtuel \texttt{/dev/shm} et tout processus qui connaît le nom et a les autorisations d'y accéder peut l'utiliser. \\
 \texttt{\textbf{sem\_t} *sem\_open(\textbf{const char} *name, \textbf{int} oflag);\\
   \textbf{sem\_t} *\textbf{sem\_open}(\textbf{const char} *name, \textbf{int} oflag, \textbf{mode\_t} mode, \textbf{unsigned int} value);\\
   \textbf{int} sem\_close(\textbf{sem\_t} *sem);\\
 \textbf{int} sem\_unlink(\textbf{const char} *name);}\\
-En cas d'erreur, \texttt{sem\_open} retourne \texttt{SEM\_FAILED} et met à jour \texttt{errno}. Les sémaphores nommés peuvent être créés et supprimés comme des fichiers. Ils utilisent des ressources limités, il faut donc bien le supprimer (avec \texttt{sem\_unlink} une fois qu'il n'est plus nécessaire.
+En cas d'erreur, \texttt{sem\_open} retourne \texttt{SEM\_FAILED} et met à jour \texttt{errno}. Les sémaphores nommés peuvent être créés et supprimés comme des fichiers. Ils utilisent des ressources limitées, il faut donc bien les supprimer (avec \texttt{sem\_unlink} une fois qu'ils ne sont plus nécessaires).
 
 \subsection{Partage de fichiers}
-Comme l'écriture dans un fichier sur un dispositif de stockage est relativement lent, l'OS maintient un buffer qui permet de ne pas devoir attendre l'écriture réelle sur le dispositif avant de continuer le processus. Pour forcer l'écriture de ce buffer sur le dispositif, on peut utiliser l'appel système \texttt{fsync} (ou \texttt{sync} si on veut le faire pour toutes les données).\\
+Comme l'écriture dans un fichier sur un dispositif de stockage est relativement lente, l'OS maintient un buffer qui permet de ne pas devoir attendre l'écriture réelle sur le dispositif avant de continuer le processus. Pour forcer l'écriture de ce buffer sur le dispositif, on peut utiliser l'appel système \texttt{fsync} (ou \texttt{sync} si on veut le faire pour toutes les données).\\
 
 Lors de l'ouverture d'un fichier sous Unix, le kernel maintient une structure de données (\textit{open file object}) qui contient le mode, l'offset pointeur, la référence vers le fichier sur le système d'exploitation. Lorsque 2 programme ouvre un même fichier, il possède chacun un \textit{open file object} différent tandis que si un fichier est ouvert avant un \texttt{fork}, le père et le fils possède le même \textit{open file object}. Ce qui peut poser problème si on déplace l'offset pointeur. Pour éviter ce problème il faut utiliser \texttt{\textbf{ssize\_t} pread(\textbf{int} fd, \textbf{void} *buf, \textbf{size\_t} count, \textbf{off\_t} offset);} et \texttt{\textbf{ssize\_t} pwrite(\textbf{int} fd, \textbf{const void} *buf, \textbf{size\_t} count, \textbf{off\_t} offset);} qui garantissent que les opérations d'écriture et de lecture qui sont effectupes se font de manière atomique et donc à l'offset pointeur voulu.\\
 
@@ -1988,21 +1988,21 @@ Unix est un OS multi-utilisateur ce qui impose des contraintes de sécurités :
 \begin{itemize}
   \item il doit être possible d'identifier et/ou d'authentifier les utilisateurs
   \item il doit être possible d'exécuter des processus appartenant à plusieurs utilisateurs simultanément et de déterminer quel utilisateur est responsable de chaque opération.
-  \item l'OS doit fournir des mécanismes simple de contrôle d'accès aux différentes ressources (mémoire, stockage,...)
+  \item l'OS doit fournir des mécanismes simples de contrôle d'accès aux différentes ressources (mémoire, stockage,...)
   \item il doit être possible d'allouer certaines ressources à un utilisateur particulier à un moment donné
 \end{itemize}
 
-Les systèmes Unix utilise le processus \texttt{login} pour la connexion d'un utilisateur. Ce processus appartient initialement à \textit{root} puis exécute l'appel système \texttt{setuid} afin d'appartenir à l'utilisateur puis exécute \texttt{execve} pour lancer le premier shell de l'utilisateur. L'appel système \texttt{setuid} ne peut évidemment être appelé que par un processus appartenant à \texttt{root}. Un processus peut récupéré son \textit{userid} avec l'appel système \texttt{getuid}.\\
+Les systèmes Unix utilisent le processus \texttt{login} pour la connexion d'un utilisateur. Ce processus appartient initialement à \textit{root} puis exécute l'appel système \texttt{setuid} afin d'appartenir à l'utilisateur puis exécute \texttt{execve} pour lancer le premier shell de l'utilisateur. L'appel système \texttt{setuid} ne peut évidemment être appelé que par un processus appartenant à \texttt{root}. Un processus peut récupéré son \textit{userid} avec l'appel système \texttt{getuid}.\\
 
 Sur Unix, le fichier \texttt{/etc/passwd} contient pour chaque utilisateur : le nom d'utilisateur (username), le mot de passe (sur les anciennes versions de Unix), l'identifiant de l'utilisateur (\textit{userid}), l'identifiant de son groupe principal, son nom et son prénom, son répertoire de démarrage, son shell.\\
 
 En pratique, on associe parfois des droits d'accès à un groupe d'utilisateur plutôt qu'à un utilisateur particulier. Le groupe principal d'un utilisateur est définit dans \texttt{/etc/passwd} tandis que les groupe secondaires le sont dans \texttt{/etc/group}.
 \subsection{Systèmes de fichiers}
-Tout les dispositifs de stockage (disque dur, lecteur CD/DVD, clé USB,...) offrent en pratique une interface similaire pour le système d'exploitation. Cette interface se résume en 2 fonction, une de lecture d'un secteur et un de l'écriture. En règle général, un \textit{\textbf{secteur}} peut stocker un bloc de 512 octets. Chaque secteur est identifié par une adresse. La plupart des implémentations sont optimisées pour pouvoir lire ou écrire plusieurs secteurs consécutifs, mais la plus petite unité de lecture ou d'écriture est le \textit{secteur}. La plupart des OS (dont Unix) fournissent une interface de plus haut niveau aux programme : les fichiers et répertoire. Cette abstraction est appelée un \textit{\textbf{système de fichiers}} ou \textit{filesystem}. Il existe des centaines de système de fichiers; Linux en supporte quelques dizaines. \\
+Tout les dispositifs de stockage (disque dur, lecteur CD/DVD, clé USB,...) offrent en pratique une interface similaire pour le système d'exploitation. Cette interface se résume en 2 fonctions, une de lecture d'un secteur et une de l'écriture. En règle général, un \textit{\textbf{secteur}} peut stocker un bloc de 512 octets. Chaque secteur est identifié par une adresse. La plupart des implémentations sont optimisées pour pouvoir lire ou écrire plusieurs secteurs consécutifs, mais la plus petite unité de lecture ou d'écriture est le \textit{secteur}. La plupart des OS (dont Unix) fournissent une interface de plus haut niveau aux programme : les fichiers et répertoire. Cette abstraction est appelée un \textit{\textbf{système de fichiers}} ou \textit{filesystem}. Il existe des centaines de système de fichiers; Linux en supporte quelques dizaines. \\
 
-En simplifiant, un système de fichier Unix utilise le principe qu'un \textit{fichier} est une suite ordonnée d'octets. Un nom est associé à cette suite d'octets. Cette suite d'octets sera stockée dans un ou plusieurs secteurs, consécutif ou non. Rien ne garantit que la taille d'un fichier sera un multiple du nombre d'octets dans un secteur, donc l'OS doit être capable de gérer des secteurs partiellement rempli.\\
+En simplifiant, un système de fichier Unix utilise le principe qu'un \textit{fichier} est une suite ordonnée d'octets. Un nom est associé à cette suite d'octets. Cette suite d'octets sera stockée dans un ou plusieurs secteurs, consécutifs ou non. Rien ne garantit que la taille d'un fichier sera un multiple du nombre d'octets dans un secteur, donc l'OS doit être capable de gérer des secteurs partiellement remplis.\\
 
-Sous Unix, le lien entre les différents secteurs qui composent un fichier se fait grâce à l'utilisation d'inodes. Un \textit{\textbf{inode}} est une structure de données stockée sur le disque (en pratique un ensemble contigu de secteur, souvent au début du disque) et qui contient notamment les méta-informations d'un fichier suivantes :
+Sous Unix, le lien entre les différents secteurs qui composent un fichier se fait grâce à l'utilisation d'inodes. Un \textit{\textbf{inode}} est une structure de données stockée sur le disque (en pratique un ensemble contigu de secteur, souvent au début du disque) et qui contient notamment les méta-informations suivantes d'un fichier :
 \begin{itemize}
   \item \texttt{uint16 mode} : Contient un ensemble de drapeaux binaires avec les permissions associées au fichier
   \item \texttt{uid\_t uid} : Le propriétaire du fichier
@@ -2016,14 +2016,14 @@ Sous Unix, le lien entre les différents secteurs qui composent un fichier se fa
 \end{itemize}
 Sous Unix, le nom de fichier n'est pas directement associé au fichier lui-même, il est stocké dans les répertoires. Un \textit{repertoire} est un fichier qui a un format spécial. Il contient une suite d'entrées qui contiennent chacune un nom (de fichier ou de répertoire), une indication de type (qui permet notamment de distinguer fichiers et répertoires) et le numéro de l'inode qui contient les méta-données du fichier ou répertoire concerné. \\
 
-Dans un système de fichier Unix, l'ensemble des répertoires et fichiers est organisé sous la forme d'un arbre. La racine de cet arbre est le répertoire \texttt{/}. Le système de fichier Unix permait aussi d'intégrer facilement des systèmes de fichiers se trouvant sur différents dispositifs de stockage. Cela peut se faire en pratique par un administrateur système avec la commande \texttt{mount} ou via le fichier \texttt{/etc/fstab}. \\
+Dans un système de fichier Unix, l'ensemble des répertoires et fichiers est organisé sous la forme d'un arbre. La racine de cet arbre est le répertoire \texttt{/}. Le système de fichier Unix permet aussi d'intégrer facilement des systèmes de fichiers se trouvant sur différents dispositifs de stockage. Cela peut se faire en pratique par un administrateur système avec la commande \texttt{mount} ou via le fichier \texttt{/etc/fstab}. \\
 
 Tout répertoire contient 2 répertoires spéciaux : \texttt{.} qui est un alias vers le répertoire lui-même, et \texttt{..} qui est un alias vers le répertoire parent du répertoire courant. \\
 
 \subsubsection{Permissions}
 \label{sysfichierutilisateur}
-Les métadonnées qui sont associés à chaque fichier ou répertoire contiennent des bits de permissions pour 3 types de permissions et d'autorisation : \texttt{r} = lecture, \texttt{w} = écriture/modification et \texttt{x} = exécution.
-Ces bits de permissions sont regroupés en 3 blocs : les permissions applicable par un processus de l'utilisateur propriétaire, les permissions applicables par un processus appartenant au même groupe que le fichier et les permissions applicables par les autres processus. Ces bits de permissions peuvent être modifié par la commande \texttt{chmod}\footnote{Voir note page 177 du syllabus pour plus d'information sur les représentation des bits de permission et l'utilisation de \texttt{chmod}}. \\
+Les métadonnées qui sont associées à chaque fichier ou répertoire contiennent des bits de permissions pour 3 types de permissions et d'autorisation : \texttt{r} = lecture, \texttt{w} = écriture/modification et \texttt{x} = exécution.
+Ces bits de permissions sont regroupés en 3 blocs : les permissions applicables par un processus de l'utilisateur propriétaire, les permissions applicables par un processus appartenant au même groupe que le fichier et les permissions applicables par les autres processus. Ces bits de permissions peuvent être modifié par la commande \texttt{chmod}\footnote{Voir note page 177 du syllabus pour plus d'informations sur les représentations des bits de permission et l'utilisation de \texttt{chmod}}. \\
 
 \subsubsection{Répertoire courant}
 Un processus peut utiliser le nom complet d'un fichier commençant par \texttt{/} (\texttt{/home/damien/Bureau/exemple.txt}) ou son nom \textit{relatif} (\texttt{Bureau/exemple.txt}). Pour les noms relatif, en fait le kernel maintient pour chaque processus le \textit{répertoire courant} dans sa table des processus. Par défaut, il s'agit du répertoire à partir duquel le programme a été lancé. Un processus peut changer son répertoire avec l'appel système \texttt{\textbf{int} chdir(\textbf{const} \textbf{char} *path);}\footnote{Depuis le shell on utilise la commande \texttt{cd} pour changer de répertoire, et la commande \texttt{pwd} pour connaître le répertoire courant}.
@@ -2055,13 +2055,13 @@ Lorsqu'un processus veut accéder à un fichier il peut utiliser les appels syst
   \item \texttt{O\_CREAT}, \texttt{O\_APPEND}, \texttt{O\_TRUNC}, \texttt{O\_CLOSEXEC}\footnote{Spécifique à Linux, si le fichier doit être automatiquement fermé lors de l'exécution de \texttt{execve}.}, et \texttt{O\_SYNC}\footnote{Indique que les opérations d'écriture doivent être faites immédiatement sans être mises en attente dans les buffers du kernel}.
   \item Une disjonction logique (opérateur \texttt{|}) des entre les drapeaux précédents
 \end{itemize}
-Lors de l'exécution de \texttt{open} (et uniquement à ce moment là), l'OS vérifie si le processus a les permissions suffisante pour accéder au fichier. Si c'est le cas, l'OS l'ouvre et retourne un \textit{descripteur de fichier}. Sous Unix, un \textbf{\textit{descripteur de fichier}} est représenté sous la forme d'un entier positif : \texttt{open} retournera le plus petit descripteur de fichier disponible. Par convention, \texttt{0} = \textit{stdin}, \texttt{1} = \textit{stdout}, \texttt{2} = \texttt{stderr}. Toutes les opérations qui sont faites sur un fichier se font en utilisant le \textit{descripteur de fichier} comme référence au fichier. Un \textit{descripteur de fichier} est une ressource limité dans un OS tel qu'Unix, il faut donc les fermer en fin d'utilisation et ne pas ouvrir inutilement un grand nombre de fichier. Pour fermer : \\
+Lors de l'exécution de \texttt{open} (et uniquement à ce moment là), l'OS vérifie si le processus a les permissions suffisantes pour accéder au fichier. Si c'est le cas, l'OS l'ouvre et retourne un \textit{descripteur de fichier}. Sous Unix, un \textbf{\textit{descripteur de fichier}} est représenté sous la forme d'un entier positif : \texttt{open} retournera le plus petit descripteur de fichier disponible. Par convention, \texttt{0} = \textit{stdin}, \texttt{1} = \textit{stdout}, \texttt{2} = \texttt{stderr}. Toutes les opérations qui sont faites sur un fichier se font en utilisant le \textit{descripteur de fichier} comme référence au fichier. Un \textit{descripteur de fichier} est une ressource limitée dans un OS tel qu'Unix, il faut donc fermer le fichier en fin d'utilisation et ne pas ouvrir inutilement un grand nombre de fichiers. Pour fermer : \\
 \texttt{\textbf{int} close(\textbf{int} fd);}\\
-Par défaut l'OS ferme les descripteur \texttt{0}, \texttt{1} et \texttt{2} à la fermeture d'un processus. \\
+Par défaut l'OS ferme les descripteurs \texttt{0}, \texttt{1} et \texttt{2} à la fermeture d'un processus. \\
 
 Lorsqu'un fichier a été ouvert, le kernel maintient les références vers l'\textit{inode} du fichier ainsi qu'un \textit{offset pointer} qui indique la position actuelle de la tête de lecture/écriture. Il est possible de déplacer cet offset pointeur en utilisant l'appel système \texttt{lseek} : \\
 \texttt{\textbf{off\_t} lseek(\textbf{int} fd, \textbf{off\_t} offset, \textbf{int} whence);}\\
-L'argument \texttt{whence} permet de définir si la position doit être calculé de manière absolue (\texttt{SEEK\_SET}) ou s'il faut l'additionner avec la valeur actuelle (\texttt{SEEK\_CUR}), ou s'il faut l'additionner à la fin du fichier (\texttt{SEEK\_END}).\\
+L'argument \texttt{whence} permet de définir si la position doit être calculée de manière absolue (\texttt{SEEK\_SET}) ou s'il faut l'additionner avec la valeur actuelle (\texttt{SEEK\_CUR}), ou s'il faut l'additionner à la fin du fichier (\texttt{SEEK\_END}).\\
 
 Pour lire et écrire on dispose de 2 fonctions : \\
 \texttt{\textbf{ssize\_t} read(\textbf{int} fd, \textbf{void} *buf, \textbf{size\_t} count);}\\
@@ -2085,7 +2085,7 @@ Note : Il est possible d'obtenir un nom de fichier unique à partir d'un templat
 
 
 \subsubsection{Les pipes}
-Un \textit{\textbf{pipe}} est un flux de bytes unidirectionnel qui relie deux processus qui ont un ancêtre commun. L'un des processus écrit sur le \textit{pipe}, tandis que l'autre peut lire sur le \textit{pipe}. Un \textit{pipe} est crée en utilisant l'appel système \texttt{pipe} : \\
+Un \textit{\textbf{pipe}} est un flux de bytes unidirectionnel qui relie deux processus qui ont un ancêtre commun. L'un des processus écrit sur le \textit{pipe}, tandis que l'autre peut lire sur le \textit{pipe}. Un \textit{pipe} est créé en utilisant l'appel système \texttt{pipe} : \\
 \texttt{\textbf{int} pipe(\textbf{int} fd[2])}\\
 Chaque fois qu'une donnée est écrite sur \texttt{fd[1]}, elle peut être lue avec \texttt{fd[0]}.
 Un \textit{pipe} a une capacité limitée\footnote{4 kB sur Linux <2.6.11 x86-32, 64 kB sur Linux > 2.6.11} lorsqu'un pipe est rempli, le processus qui effectue \texttt{write} est bloqué.

--- a/src/q4/os-SINF1225/summary/os-SINF1225-summary.tex
+++ b/src/q4/os-SINF1225/summary/os-SINF1225-summary.tex
@@ -268,7 +268,7 @@ Il faut donc choisir le type de variable (\texttt{short}, \texttt{int}, \texttt{
 
 \subsection{Nombres réels}
 Pour un nombre réels sur 32 bits (resp 64 bits) on a : seeeeeeeemmmmmmmmmmmmmmmmmmmmmmm avec $s$ le signe sur 1 bit, $e$ l'exposant sur 8 bits (resp 11) et $m$ la fraction (ou mantise) sur 23 bits (resp 52)
-$$(-1)^s\times(1+\sum^23_{i=1} m_i 2^{-i})\times 2^{e-E_{max}})$$
+$$(-1)^s\times(1+\sum^{23}_{i=1} m_i 2^{-i})\times 2^{e-E_{max}})$$
 Il est intéressant de noter que
 \begin{itemize}
   \item une représentation en virgule flottante sur $n$ bits ne permet jamais de représenter plus de $2^n$ nombres réels différents.

--- a/src/q4/os-SINF1225/summary/os-SINF1225-summary.tex
+++ b/src/q4/os-SINF1225/summary/os-SINF1225-summary.tex
@@ -239,8 +239,8 @@ Plusieurs représentations de séquence de bits existent : \\
 \begin{tabular}{l||l|c|c|l}
   \textbf{Représentation} &  & \textbf{Base} & \textbf{Plage} & \textbf{Exemple} \\
   \hline \hline \textbf{Binaire} & Représente 1 bit & 2 & [0-1] & \texttt{0b1111011} \\
-  \hline \textbf{Octal} & Représente 3 bits & 8 & [0-7] & \texttt{0x07b} \\
-  \hline \textbf{Hexadécimal} & Représente 4 bits (nibble) & 16 & [0-9A-F] & \texttt{0173} \\
+  \hline \textbf{Octal} & Représente 3 bits & 8 & [0-7] & \texttt{0173} \\
+  \hline \textbf{Hexadécimal} & Représente 4 bits (nibble) & 16 & [0-9A-F] & \texttt{0x07b} \\
   \hline \textbf{Décimal} &  & 10 & [0-9] & \texttt{123} \\
   \hline
 \end{tabular} \\


### PR DESCRIPTION
Quelques corrections dans l'ensemble du document : 
* fautes de grammaire/orthographe;
* tableau trop long;
* syntaxe latex.

Il faudrait changer aussi le code du cours: c'est [1252](http://www.uclouvain.be/cours-2015-SINF1252), pas [1225](http://www.uclouvain.be/cours-2015-SINF1225). Mais je ne suis pas sûr comment faire ça sans bousiller le repo :stuck_out_tongue_winking_eye:.