### PR TITLE
Update algo-SINF1121-summary.tex

### DIFF
--- a/src/q5/algo-SINF1121/summary/algo-SINF1121-summary.tex
+++ b/src/q5/algo-SINF1121/summary/algo-SINF1121-summary.tex
@@ -1384,8 +1384,7 @@ returns she and the , and keysThatMatch("s..") returns she and sea .}
 \subsubsection{Basic Tries}
 
 \begin{mydef}[Tries]
-A \textit{trie} is a search tree build from the characters of the string keys that allows the use the characters of the search
-key to guide the search. A trie has the same structure as a search tree. We usually omit null links due to a substantial number of these one. Each node corresponds to a character value (except the root) and is associated to a value, which can be \textit{null} or the value associated to one of the string key of the symbol table. A representation is given fig \ref{Basic trie}.
+A \textit{trie} is a search tree build from the characters of the string keys that allows us to use the characters of the search key to guide the search. A trie has the same structure as a search tree. We usually omit null links due to a substantial number of these one. Each node corresponds to a character value (except the root) and is associated to a value, which can be \textit{null} or the value associated to one of the string key of the symbol table. A representation is given fig \ref{Basic trie}.
 \end{mydef}
 
 
@@ -1407,6 +1406,12 @@ in the search for shell depicted at top right above). This result is a \textbf{s
 the key is not in the table.}
 \item{The search terminated with a null link (as in the search for shore depicted at
 bottom right above). This result is also a \textbf{search miss}.}
+\end{itemize}
+
+\paragraph{Node Representation}
+\begin{itemize}
+	\item{Every node has R links, one for each possible character.}
+	\item{Characters and keys are implicitely stored in the data structure.}
 \end{itemize}
 
 An example of search is given fig \ref{Search in a basic trie}.
@@ -1442,47 +1447,47 @@ A implementation of a trie is given below:
 public class TrieST<Value>
 {
 
-private static int R = 256; // radix
-private Node root;
-// root of trie
+   private static int R = 256; // radix or number of possible characters
+   private Node root;
+   // root of trie
 
-private static class Node
-{
+   private static class Node
+   {
 	private Object val;
 	private Node[] next = new Node[R];
-}
+   }
 
-public Value get(String key)
-{
+   public Value get(String key)
+   {
 	Node x = get(root, key, 0);
 	if (x == null) return null;
 	return (Value) x.val;
-}
+   }
 
-private Node get(Node x, String key, int d)
-{ // Return value associated with key in the subtrie rooted at x.
-	if (x == null) return null;
+   private Node get(Node x, String key, int d)
+   { // Return value associated with key in the subtrie rooted at x.
+ 	if (x == null) return null;
 	if (d == key.length()) return x;
 	char c = key.charAt(d); // Use dth key char to identify subtrie.
 	return get(x.next[c], key, d+1);
-}
+   }
 
-public void put(String key, Value val)
-{ root = put(root, key, val, 0); }
+   public void put(String key, Value val)
+   { root = put(root, key, val, 0); }
 
-private Node put(Node x, String key, Value val, int d)
-{ // Change value associated with key if in subtrie rooted at x.
+   private Node put(Node x, String key, Value val, int d)
+   { // Change value associated with key if in subtrie rooted at x.
 	if (x == null) x = new Node();
 	if (d == key.length()) { x.val = val; return x; }
 	char c = key.charAt(d); // Use dth key char to identify subtrie.
 	x.next[c] = put(x.next[c], key, val, d+1);
 	return x;
-}
+  }
 }
 \end{lstlisting}
 
 \paragraph{Collecting keys}
-Because keys are represented implicitly in the trie, it is difficult to provide to user the ability to iterate through the keys. We do not use a queue to stock the different keys as with the binary search tree but we create a explicit representation of all the string keys using the recursive method \textit{collect()}. This method visits the differents nodes and appends the corresponding characters to create the keys. The \textit{collect()} method is use to implements the \textit{keysWithPrefix()} method which is used to implements the \textit{keys()} method. The last one allow to create all the different keys (exemple given fig \ref{keysRe}). A implementation of the  \textit{collect()}, \textit{keysWithPrefix} and \textit{keys()} methods are given below: 
+Because keys are represented implicitly in the trie, it is difficult to provide user the ability to iterate through the keys. We do not use a queue to stock the different keys as with the binary search tree but we create an explicit representation of all the string keys using the recursive method \textit{collect()}. This method visits the different nodes and appends the corresponding characters to create the keys. The \textit{collect()} method is used to implement the \textit{keysWithPrefix()} method which is used to implement the \textit{keys()} method. The last one allows to create all the different keys (exemple given fig \ref{keysRe}). An implementation of the  \textit{collect()}, \textit{keysWithPrefix} and \textit{keys()} methods are given below: 
 
 \begin{lstlisting}
 public Iterable<String> keys()
@@ -1504,7 +1509,7 @@ private void collect(Node x, String pre, Queue<String> q)
 }
 \end{lstlisting} 
 
-The \textit{keysThatMatch()} method use the similar process, but add an argument to specify the pattern to collect. A possible implementation is given below:
+The \textit{keysThatMatch()} method uses the similar process, but adds an argument to specify the pattern to collect. A possible implementation is given below:
 
 \begin{lstlisting}
 public Iterable<String> keysThatMatch(String pat)
@@ -1527,7 +1532,7 @@ public void collect(Node x, String pre, String pat, Queue<String> q)
 }
 \end{lstlisting}
 
-The \textit{longuestPrefix()} method first looks for the biggest length found for a path that matches with the parameter string and then return a substring with the obtained length
+The \textit{longuestPrefix()} method first looks for the biggest length found for a path that matches with the parameter string and then returns a substring with the obtained length. See code below:
 
 \begin{lstlisting}
 public String longestPrefixOf(String s)
@@ -1557,8 +1562,7 @@ private int search(Node x, String s, int d, int length)
 AS for the insertion, the first step of a deletion is a search: the goal is to find the node corresponding to the key and set its value to null. Two situations may occur then:
 \begin{itemize}
 \item{The node has non-null link to a child. No more work is required}
-\item{All the remaining link are null. We have thus to remove the node. Caution that if doing so leaves all the links null in its parent, we need to remove that node,
-and so forth.}
+\item{All the remaining links are null. We thus have to remove the node. Caution that if doing so leaves all the links null in its parent, we need to remove that node, and so forth.}
 \end{itemize}
 A exemple is given fig \ref{trieDel}. A possible implementation is given below:
 \begin{lstlisting}


### PR DESCRIPTION
Corrections mineures, orthographe.
Ajout de l'explication de R pour la taille du tableau des noeuds
On pourrait peut être ajouter l'image à la page 734 ? Elle explique bien les noeuds qui contiennent un tableau avec tous les caractères possibles.