### PR TITLE
LINGI1123 - Calculabilité et Complexité - Petites erreurs dans 2 démonstrations

### DIFF
--- a/src/q6/calcu-INGI1123/summary/calcu-INGI1123-summary.tex
+++ b/src/q6/calcu-INGI1123/summary/calcu-INGI1123-summary.tex
@@ -1389,9 +1389,9 @@ Ce qui conclut notre démonstration.
     On remarque que par construction pour tout $k$, $\phi_{f(k)} \neq \phi_k$.
     \begin{itemize}
       \item Si $k \in K$, $\phi_k(k) \neq \bot$, $f(k) = 1$ et
-        $\phi_{f(k)}(k) = \phi_1(k) \neq \bot = \phi_k(k)$ donc $\phi_{f(k)} \neq \phi_k$.
+        $\phi_{f(k)}(k) = \phi_1(k) = \bot \neq \phi_k(k)$ donc $\phi_{f(k)} \neq \phi_k$.
       \item Si $k \notin K$, $\phi_k(k) = \bot$, $f(k) = 0$ et
-        $\phi_{f(k)}(k) = \phi_0(k) = \bot \neq \phi_k(k)$ donc $\phi_{f(k)} \neq \phi_k$.
+        $\phi_{f(k)}(k) = \phi_0(k) \neq \bot = \phi_k(k)$ donc $\phi_{f(k)} \neq \phi_k$.
     \end{itemize}
     Si $K$ est récursif, alors $f$ est total calculable.
 	Par le théorème du point fixe, il existe $k$ tel que $\phi_k = \phi_{f(k)}$.

--- a/src/q6/calcu-INGI1123/summary/calcu-INGI1123-summary.tex
+++ b/src/q6/calcu-INGI1123/summary/calcu-INGI1123-summary.tex
@@ -1388,12 +1388,11 @@ Ce qui conclut notre démonstration.
 	\end{itemize}
     On remarque que par construction pour tout $k$, $\phi_{f(k)} \neq \phi_k$.
     \begin{itemize}
-      \item Si $k \in K$, $\phi_k(k) \neq \bot$, $f(k) = 0$ et
-        $\phi_{f(k)}(k) = \phi_0(k) = \bot \neq \phi_k(k)$ donc $\phi_{f(k)} \neq \phi_k$.
-      \item Si $k \notin K$, $\phi_k(k) = \bot$, $f(k) = 1$ et
+      \item Si $k \in K$, $\phi_k(k) \neq \bot$, $f(k) = 1$ et
         $\phi_{f(k)}(k) = \phi_1(k) \neq \bot = \phi_k(k)$ donc $\phi_{f(k)} \neq \phi_k$.
+      \item Si $k \notin K$, $\phi_k(k) = \bot$, $f(k) = 0$ et
+        $\phi_{f(k)}(k) = \phi_0(k) = \bot \neq \phi_k(k)$ donc $\phi_{f(k)} \neq \phi_k$.
     \end{itemize}
-
     Si $K$ est récursif, alors $f$ est total calculable.
 	Par le théorème du point fixe, il existe $k$ tel que $\phi_k = \phi_{f(k)}$.
     Ce qui est contradictoire.

--- a/src/q6/calcu-INGI1123/summary/calcu-INGI1123-summary.tex
+++ b/src/q6/calcu-INGI1123/summary/calcu-INGI1123-summary.tex
@@ -1336,7 +1336,7 @@ Ce qui conclut notre démonstration.
   À l'aide du point fixe, on peut démontrer une version plus forte du théorème de Rice:
 
   Si $A$ est récursif et $A \neq \emptyset \neq \bar{A}$, alors
-  pour tout $n \in A$ et $m \in \bar{A}$,
+  il existe $n \in A$ et $m \in \bar{A}$,
   \begin{itemize}
     \item soit $\exists k \in      A $ tel que $\phi_m = \phi_k$
     \item soit $\exists k \in \bar{A}$ tel que $\phi_n = \phi_k$.


### PR DESCRIPTION
Erreurs dans les démonstrations suivantes : 
* K non récursif grâce au théorème du point fixe (petite erreur de raisonnement);
* Théorème de Rice grâce au théorème du point fixe (mauvais énoncé du théorème dans sa version plus forte).

Pour plus de détails, voir la description des 2 commits :)