### PR TITLE
Correction d'une erreur dans la formule de cosh(x)

### DIFF
--- a/src/q3/math-FSAB1103/summary/math-FSAB1103-summary.tex
+++ b/src/q3/math-FSAB1103/summary/math-FSAB1103-summary.tex
@@ -983,7 +983,7 @@ Nous avons plusieurs cas à traiter:
 
 \begin{mydef}[Fonctions Hyperboliques]
 	\begin{align*}
-		&\cosh(z) = \frac{e^{z} + e^{iz}}{2}
+		&\cosh(z) = \frac{e^{z} + e^{-z}}{2}
 		&\sinh(z) = \frac{e^{z} - e^{-z}}{2}
 	\end{align*}
 \end{mydef}


### PR DESCRIPTION
cosh(x)= (exp(z) + exp(-z))/2 et pas (exp(z) + exp(iz))/2