### PR TITLE
Update sigsys-FSAB1106-exam-2017-Juin-All.tex

### DIFF
--- a/src/q4/sigsys-FSAB1106/exam/2017/Juin/All/sigsys-FSAB1106-exam-2017-Juin-All.tex
+++ b/src/q4/sigsys-FSAB1106/exam/2017/Juin/All/sigsys-FSAB1106-exam-2017-Juin-All.tex
@@ -84,8 +84,8 @@ Remarque : l'énoncé de cette question est incomplet, notamment la démonstrati
 	Y[k] &= \sum_{n=0}^{N-1} y[n] e^{- \frac{2 \pi j k n}{N}} \\
 	&= \sum_{n=0}^{N-1} x[n] (-1)^n e^{- \frac{2 \pi j k n}{N}} \\
 	&= \sum_{n=0}^{N-1} x[n] e^{- \pi j n} e^{- \frac{2 \pi j k n}{N}} \\
-	&= \sum_{n=0}^{N-1} x[n] e^{- \pi j n} e^{- \frac{2 \pi j k n + \pi j N n}{N}} \\
-	&= \sum_{n=0}^{N-1} x[n] e^{- \pi j n} e^{- \frac{2 \pi j (k + \frac{N}{2}) n}{N}} \\
+	&= \sum_{n=0}^{N-1} x[n] e^{- \frac{2 \pi j k n + \pi j N n}{N}} \\
+	&= \sum_{n=0}^{N-1} x[n] e^{- \frac{2 \pi j (k + \frac{N}{2}) n}{N}} \\
 	&= X \left[ k + \frac{N}{2} \right]
 	\end{align*}
 	On a simplement décalé la DFT de $N/2$.
@@ -426,7 +426,7 @@ On considère un système causal décrit par la fonction de transfert
 
 \begin{solution}
 \begin{enumerate}[label=(\alph*)]
-	\item Les pôles de la fonction de transfert sont en $1$, en $-\frac{3}{4} + i\frac{\sqrt{7}}{2}$ et en $-\frac{3}{4} - i\frac{\sqrt{7}}{2}$. Comme $1$ est à droite de l'axe imaginaire, et que le système est causal, le système n'est pas stable BIBO (il faudrait que tous les pôles soient à gauche de l'axe imaginaire, donc à partie réelle négative).
+	\item Les pôles de la fonction de transfert sont en $1$, en $-\frac{3}{4} + i\frac{\sqrt{7}}{4}$ et en $-\frac{3}{4} - i\frac{\sqrt{7}}{4}$. Comme $1$ est à droite de l'axe imaginaire, et que le système est causal, le système n'est pas stable BIBO (il faudrait que tous les pôles soient à gauche de l'axe imaginaire, donc à partie réelle négative).
 	\item Pour cela, il faut une fonction de transfert dont le numérateur élimine le pôle à partie réelle positive, et dont les pôles soient à partie réelle négative. Par exemple,
 	\[H(s) = \frac{s-1}{(s+1)(s+2)}\]
 	%FIXME pas sûr


### PR DESCRIPTION
correction : LV2 : c) présence d'une exponentielle en trop dans les deux dernières lignes et VW1 : a) erreur dans le deno d ela partie imaginaire des poles de H