### PR TITLE
Fix erreur dans README.md et fix #473

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Les `.pdf` des synthèses et correctifs dans leur dernière version sont disponi
 Ce README donne quelques premières indications
 quant à l'utilisation de ce repository.
 Pour de plus amples informations,
-voir le
+voir
 le document [How_to_Contribute][doc-url]
 ou le [wiki](https://github.com/Gp2mv3/Syntheses/wiki).
 

--- a/src/eplformulaire.cls
+++ b/src/eplformulaire.cls
@@ -12,8 +12,8 @@
 \LoadClass{../../../eplbase}
 
 \IfLanguageName{english}{
-\newcommand{\Epltype}{Formulary}
-\newcommand{\epltypesingular}{formulary} % si quelqu'un connait la vraie traduction en anglais
+\newcommand{\Epltype}{Cheat sheet}
+\newcommand{\epltypesingular}{cheat sheet} % si quelqu'un connait la vraie traduction en anglais
 }{
 \newcommand{\Epltype}{Formulaire}
 \newcommand{\epltypesingular}{formulaire} % version au singulier


### PR DESCRIPTION
Ce commit corrige une petite erreur dans le readme ainsi que la
traduction du mot formulaire, comme discuté dans l'issue #473.