### PR TITLE
Fix myprop, formatting in edo & issue in proba/prostoch

### DIFF
--- a/src/eplcommon.sty
+++ b/src/eplcommon.sty
@@ -111,7 +111,7 @@
 {
 \newtheorem{mydef}{Définition}
 \newtheorem{mynota}[mydef]{Notation}
-\newtheorem{myprop}[mydef]{Propriétés}
+\newtheorem{myprop}[mydef]{Propriété}
 \newtheorem{myrem}[mydef]{Remarque}
 \newtheorem{myform}[mydef]{Formules}
 \newtheorem{mycorr}[mydef]{Corrolaire}

--- a/src/q4/edo-MAT1223/summary/edo-MAT1223-summary.tex
+++ b/src/q4/edo-MAT1223/summary/edo-MAT1223-summary.tex
@@ -7,6 +7,17 @@
 \DeclareMathOperator{\newnull}{null}
 \newcommand{\sol}{\mathcal{S}}
 
+\makeatletter
+\DeclareRobustCommand{\genericinterval}[2]{%
+  \@ifstar{\genericinterval@star{#1}{#2}}{\genericinterval@nostar{#1}{#2}}}
+\newcommand{\genericinterval@star}[4]{\mathopen{}\mathclose{\left#1#3,#4\right#2}}
+\newcommand{\genericinterval@nostar}[4]{\mathopen{#1}#3,#4\mathclose{#2}}
+\newcommand{\intervalcc}{\genericinterval[]}
+\newcommand{\intervaloo}{\genericinterval][}
+\newcommand{\intervaloc}{\genericinterval]]}
+\newcommand{\intervalco}{\genericinterval[[}
+\makeatother
+
 \hypertitle[']{\'Equations diff\'erentielles ordinaires}{4}{MAT}{1223}
 {Beno\^it Legat}
 {Jean Van Schaftingen}
@@ -15,7 +26,7 @@
 Nous allons traiter la résolution, l'existence et l'unicité des solutions
 de l'équation différentielle ordinaire
 \[ u'(t) = A[u(t)] \]
-où $u:I\to\Rn$ est une fonction vectorielle,
+où $u\colon I\to\Rn$ est une fonction vectorielle,
 $I \subseteq \R $ un intervalle et $t \in I$.
 Dans cette section, $A$ sera une matrice à coefficients constants.
 
@@ -24,10 +35,10 @@ On remarque que si $u$ et donc $A$ sont scalaires, la solution est
 d'où l'intuition qui semble parachutée de la solution pour $u(t)$ vectoriel
 \[ u(t) = \lim_{m\to\infty} \sum_{k=0}^m\frac{(tA)^k[u(0)]}{k!}. \]
 
-Seulement, il nous faut s'assurer de deux choses
+Seulement, il nous faut s'assurer de deux choses :
 \begin{itemize}
-  \item La limite converge bien;
-  \item C'est bien solution,
+  \item la limite converge bien;
+  \item c'est bien solution,
     c'est à dire que c'est dérivable et que $u(t)$ défini
     ainsi satisfait bien $u'(t) = A[u(t)]$.
 \end{itemize}
@@ -36,7 +47,7 @@ On peut démontrer que c'est bien le cas.
 On définit alors l'\emph{exponentielle d'opérateur}
 \[ \e^{A}[v] \eqdef \lim_{k\to\infty} \sum_{i=0}^k \frac{A^i[v]}{i!}. \]
 Il faut faire attention à ne pas se laisser tromper par la notation.
-Ce n'est pas un exponentielle comme les autres, on a pas toutes les propriétés
+Ce n'est pas un exponentielle comme les autres, on n'a pas toutes les propriétés
 des exponentielles classiques.
 Par exemple, en général, $\e^{A + B} \neq \e^A \circ \e^{B}$.
 On a par contre
@@ -48,14 +59,14 @@ On a par contre
 %faudrait enlever les s à propriétés en général
 %t'en définis qu'une à la fois nan ? ;)
 \begin{myprop}[Existence, unicité et solution]
-  Soit $A \in \lin(\R^n, \R^n)$ et $u_0 \in \R^n$,
+  Soit $A \in \lin(\Rn, \Rn)$ et $u_0 \in \Rn$,
   il \emph{existe} une solution
-  $u:\R\to\R^n$ du problème
+  $u\colon \R\to\Rn$ du problème
   \begin{align*}
     u'(t) & = A[u(t)]\\
-    u(t_0) & = u_0
+    u(t_0) & = u_0.
   \end{align*}
-  cette solution est $u(t) = \e^{(t-t_0)A}[u_0]$ et est \emph{unique}.
+  Cette solution est $u(t) = \e^{(t-t_0)A}[u_0]$ et est \emph{unique}.
 \end{myprop}
 Pour $u'(t) = A[u(t)] + b(t)$, la solution devient
 \[ u(t) = \e^{(t-t_0)A}[u_0] + \int_{t_0}^t \e^{(t-s)A}[b(s)]\dif s. \]
@@ -81,7 +92,7 @@ On pourra alors tout simplement écrire
 où $\lambda_1, \ldots, \lambda_m$ sont les $m$ valeurs propres généralisées
 de degré $k_i$ où $\sum_{i=1}^m k_i = n$.
 
-La projection des $v$ en vecteurs propres $v_i$ peut être modélisé
+La projection des $v$ en vecteurs propres $v_i$ peut être modélisée
 par un produit matriciel $v_i = P_i v$.
 On peut alors mettre en évidence $v$ dans la formule précédente et en posant
 $B_{i,j} = (A-\lambda_i I)^j P_i$, on a
@@ -93,10 +104,10 @@ c'est qu'il existe une certaine matrice $B_{i,j}$,
 sa valeur exacte n'est pas utilisée aussi souvent que le fait que $B_{i,j}$
 existe.
 
-En effet, un des corrolaires importants de cet identité est que
+En effet, un des corrolaires importants de cette identité est que
 si $\sigma > \Re(\lambda)$ $\forall \lambda \in \spec A$,
 il existe $C \geq 1$ tel que
-\[ \|\e^{tA}\| \leq C\e^{\sigma t}. \]
+\[ \norm{\e^{tA}} \leq C\e^{\sigma t}. \]
 C'est une inégalité assez utile,
 ça permet par exemple de dire que si
 $\Re(\lambda) < 0$, $\forall \lambda \in \spec(A)$,
@@ -105,17 +116,17 @@ $\lim_{t\to 0} \e^{tA} = 0$.
 
 \section{EDO à coefficients variables}
 Nous allons étudier l'EDO suivante.
-Soit $I \subseteq \R$ un intervalle et $u:I\to\R^n$ dérivable tel que
+Soit $I \subseteq \R$ un intervalle et $u\colon I\to\Rn$ dérivable tel que
 \begin{align*}
   u'(t) & = A(t)[u(t)] + f(t) & \forall t \in I\\
   u(t_0) & = u_0
 \end{align*}
-où $A : I \to \lin(\R^n)$ est continue.
+où $A \colon I \to \lin(\Rn)$ est continue.
 
 On peut démontrer que cette EDO a toujours une solution et que cette
 solution est unique.
 C'est à dire que si on a deux fonctions $u_1$ et $u_2$ qui satisfont
-l'EDO pour les même $t_0$ et $u_0$, on a en fait
+l'EDO pour les mêmes $t_0$ et $u_0$, on a en fait
 $u_1(t) = u_2(t)$ $\forall t \in I$.
 
 \subsection{Structure de la solution}
@@ -153,7 +164,7 @@ Sa définition est la suivante
 
 \begin{mydef}[Résolvante]
   \label{def:res}
-  La résolvante $R: I \times I \to \lin(R^n)$ est l'unique fonction
+  La résolvante $R\colon I \times I \to \lin(R^n)$ est l'unique fonction
   telle que, si
   \[ u'(r) = A(r)[u(r)] \]
   $\forall r \in I$, alors $\forall s, t \in I$
@@ -177,13 +188,13 @@ de $u(t)$.
   \end{proof}
 \end{myprop}
 
-On peut peut montrer que $u(t)$ est solution de l'EDO si et seulement si
+On peut montrer que $u(t)$ est solution de l'EDO si et seulement si
 \[ u(t) = R(t, t_0)[u_0] + \int_{t_0}^t R(t,s)[f(s)] \dif s. \]
 On a aussi que
 \[ R(t, s) = R(t, r) \circ R(r, s). \]
 
 Pour la calculer, on prend $n$ solutions $u_i$ linéairement indépendantes
-de $u'(t) = A(t)[u(t)]$, c'est à dire une base de $\sol$, et on prend
+de $u'(t) = A(t)[u(t)]$, c'est-à-dire une base de $\sol$, et on prend
 
 \[ R(s, t) =
   \begin{pmatrix}
@@ -222,7 +233,7 @@ On trouve en effet une solution en prenant $\alpha_i(t)$ tels que
   \label{eq:cialpha}
   \sum_{i=1}^n \alpha_i(t_0)u_i(t_0) & = u_0.
 \end{align}
-On trouve $\alpha_i'(t)$ grâce les
+On trouve $\alpha_i'(t)$ grâce aux
 $n$ équations données par \eqref{eq:dalpha}
 et il nous reste plus qu'à intégrer à l'aide des
 $\alpha_i(t_0)$ trouvés grâce aux
@@ -261,26 +272,26 @@ On va avoir besoin d'une première solution $u_1 \neq 0$,
 on sait qu'il en existe une mais
 il faut avoir un peu d'intuition pour la trouver.
 
-Il nous faut maintenant prendre un vecteur $e$ tel que $(e|u_1)$
+Il nous faut maintenant prendre un vecteur $e$ tel que $\la e,u_1 \ra$
 ne s'annule jamais.
 Il est toujours possible de trouver ce $e$ pour un certain intervalle
 car $u_1$ ne s'annule jamais partout à moins que
 $u_1$ soit la solution triviale nulle mais on a supposé que $u_1 \neq 0$ car
 on ne sait pas construire de solution à partir de rien.
 
-On pose ensuite (sans perte de généralité, disons qu'on a pris $(0,1)$)
+On pose ensuite (sans perte de généralité, disons qu'on ait pris $(0,1)$)
 \[ u_2(t) = \alpha(t)u_1(t) + \beta(t)(0,1) \]
 avec $\alpha,\beta$ des fonctions scalaires à déterminer.
 On écrit alors $u_2'(t) = A[u_2(t)]$.
 Il devrait apparaitre à gauche $\alpha(t) u_1'(t)$ et à droite
 $\alpha(t) A[u_1(t)]$ qu'on peut simplifier.
-Ça nous fait un système de deux équation différentielles du premier degré
+Ça nous fait un système de deux équations différentielles du premier degré
 en $\alpha(t)$ et $\beta(t)$ qu'il faut résoudre pour finalement trouver
 $u_2(t)$.
 Seulement, ce système est plus facile à résoudre que celui de départ
 car dans la première équation, on a simplement
 \[ \alpha'(t)u_{1;1}(t) = \beta(t)A_{1,2} \]
-où $u_{1;1}$ est la première composante de $u_1$ et $A_{1;2}$ est
+où $u_{1;1}$ est la première composante de $u_1$ et $A_{1,2}$ est
 la composante de $A$ sur la première ligne et la deuxième colonne.
 D'où on tire directement $\beta(t)$ qu'on peut réinjecter dans la deuxième
 où il n'y aura alors que des $\alpha$ qu'on peut alors trouver ce qui nous
@@ -301,63 +312,63 @@ On va étudier les équations du type
 \[ u'(t) = f(t, u(t)). \]
 
 \subsection{Existence et unicité}
-Commençons par définir ce qu'est un champ de vecteur et
+Commençons par définir ce qu'est un champ de vecteurs et
 une courbe intégrale
-\begin{mydef}[Champ de vecteur]
+\begin{mydef}[Champ de vecteurs]
   Soit $\Omega \subseteq \R \times \Rn$,
   un \emph{champ de vecteurs} sur $\Omega$ est une fonction
-  $f:\Omega \to \Rn$.
+  $f\colon \Omega \to \Rn$.
 \end{mydef}
 \begin{mydef}[Courbe intégrale]
-  Soit $\Omega \subseteq \R \times \Rn$ et $f:\Omega\to\Rn$
-  un champ de vecteur sur $\Omega$.
+  Soit $\Omega \subseteq \R \times \Rn$ et $f\colon \Omega\to\Rn$
+  un champ de vecteurs sur $\Omega$.
   Soit $I \subseteq \R$ un intervalle \emph{ouvert}.
-  La fonction $u:I\to\Rn$ est une \emph{courbe intégrale} de $f$ si $u$
+  La fonction $u\colon I\to\Rn$ est une \emph{courbe intégrale} de $f$ si $u$
   est \emph{dérivable} et si pour tout $t\in I$, $(t, u(t)) \in \Omega$ et
   \[ u'(t) = f(t, u(t)). \]
 \end{mydef}
 En gros, une courbe intégrale est une courbe qui respecte l'équation
-$u'(t) = f(t, u(t))$ et qui reste dans le champ de vecteur $\Omega$
+$u'(t) = f(t, u(t))$ et qui reste dans le champ de vecteurs $\Omega$
 ($(t, u(t)) \in \Omega$).
 
 On peut s'assurer de l'existence d'une courbe intégrale dans un domaine
-borné en s'assurant que $||f||$ ne dépasse pas une limite.
-C'est comme quand la police cherche un prisonnier mais qu'ils savent
+borné en s'assurant que $\norm{f}$ ne dépasse pas une limite.
+C'est comme quand la police cherche un prisonnier mais qu'elle sait
 qu'il est à pied et donc qu'il ne va pas à plus de
 % 12 km/h pfff petit joueur
 \si{12}{\kilo\meter\per\hour}, elle peut dessiner un cercle de
 \si{6}{\kilo\meter} de rayon
-et elle est sûre que le prisonnier n'en sortira pas en
-une demi-heure.
+et elle est sûre que le prisonnier n'en sortira pas en moins
+d'une demi-heure.
 C'est ce qui est dit de manière plus formelle par
 la propriété~\ref{prop:cauchy_peano}.
 \begin{myprop}[Cauchy-Peano]
   \label{prop:cauchy_peano}
   Soit $t_0 \in \R$, $h > 0$, $r > 0$,
-  $u_0 \in \Rn$ et $f:]t_0-h,t_0+h[\times B(u_0,r)\to\Rn$ un champ de vecteurs
-  continu.
-  Si pour tout $(t,x) \in ]t_0-h,t_0+h[ \times B(u_0,r)$,
-  \[ h\|f(t,x)\| \leq r, \]
-  alors il existe $u:]t_0-h,t_0+h[ \to B(0,r)$
+  $u_0 \in \Rn$ et $f\colon \intervaloo{t_0-h}{t_0+h} \times B(u_0,r)\to\Rn$ un
+  champ de vecteurs continu.
+  Si pour tout $(t,x) \in \intervaloo{t_0-h}{t_0+h} \times B(u_0,r)$,
+  \[ h \norm{f(t,x)} \leq r, \]
+  alors il existe $u\colon \intervaloo{t_0-h}{t_0+h} \to B(0,r)$
   qui soit une courbe intégrale de $f$.
 \end{myprop}
 
 Pour l'unicité, on va devoir utiliser le concept de champ lipschitzien.
 \begin{mydef}[Champ de vecteurs lipschitzien en espace]
   Soit $\Omega \subseteq \R \times \Rn$.
-  Le champ de vecteurs $f:\Omega\to\Rn$ est \emph{lipschitzien
+  Le champ de vecteurs $f\colon \Omega\to\Rn$ est \emph{lipschitzien
   en espace}, s'il existe $L \geq 0$ tel que pour tout
   $t\in\R$, $x,y\in\Rn$, si $(t,x) \in \Omega$ et $(t,y) \in \Omega$, alors
-  \[ \|f(t,x) - f(t,y)\| \leq L \|x - y\|. \]
+  \[ \norm{f(t,x) - f(t,y)} \leq L \norm{x - y}. \]
 \end{mydef}
 \begin{mydef}[Champ de vecteurs localement lipschitzien en espace]
   Soit $\Omega \subseteq \R \times \Rn$.
-  Le champ de vecteurs $f:\Omega\to\Rn$ est \emph{localement lipschitzien
+  Le champ de vecteurs $f\colon \Omega\to\Rn$ est \emph{localement lipschitzien
   en espace}, si pour tout
   $(t,x) \in \Omega$,
   il existe $r > 0$ et $h > 0$ tels que
   $f$ est lipschitzien en espace sur
-  $]t-h,t+h[ \times B(x,r) \subseteq \Omega$.
+  $\intervaloo{t-h}{t+h} \times B(x,r) \subseteq \Omega$.
 \end{mydef}
 On remarque que si $f$ est lipschitzien, alors $f$ est localement lipschitzien
 et que si $f$ est de classe $C_1$ en espace, alors $f$ est localement
@@ -365,13 +376,13 @@ lipschitzien en espace.
 
 L'élément clef qui fait qu'il est plus facile d'être localement lipschitizen
 que lipschitzien c'est que pour localement lipschitzien, $L$ peut changer
-pour chaque $]t-h,t+h[ \times B(x,r)$.
+pour chaque $\intervaloo{t-h}{t+h} \times B(x,r)$.
 C'est ce qui aide dans l'exemple~\ref{ex:tabsx} et l'exemple~\ref{ex:harm}.
 
 Essayons de comprendre tout cela avec des exemples.
 \begin{myexem}
   \label{ex:ux}
-  Prenons $\Omega = \R\times\R\setminus\{0\}$ et $f:\Omega\to\R$ définit par
+  Prenons $\Omega = \R\times\R\setminus\{0\}$ et $f\colon \Omega\to\R$ définit par
   \[
     f(t,x) =
     \begin{cases}
@@ -384,22 +395,22 @@ Essayons de comprendre tout cela avec des exemples.
   Par contre, il n'est pas lipschitzien.
   En effet, si on prend $x < 0$ et $y > 0$, on prenant $x$ et $y$ aussi
   prochent de $0$ que l'on veut,
-  on sait avoir $\frac{\|f(t,y)-f(t,x)\|}{\|y-x\|}$
+  on sait avoir $\frac{\norm{f(t,y)-f(t,x)}}{\norm{y-x}}$
   aussi grand que l'on veut.
 
   Il est localement lipschitzien car même en prenant $x$
   aussi proche de $0$ que l'on veut,
-  il suffit de prendre $r \leq |x|$.
+  il suffit de prendre $r \leq \abs{x}$.
   On n'aura pas de problème avec $x = 0$ car il n'est pas dans $\Omega$.
 \end{myexem}
 \begin{myexem}
   \label{ex:harm}
   Prenons $\Omega = \R\times\R_{>0}$ et
-  $f:\Omega\to\R:f(t,x)\mapsto \frac{1}{x}$.
+  $f\colon \Omega\to\R\colon f(t,x)\mapsto \frac{1}{x}$.
   $f$ est de classe $C_1$ sur $\Omega$ et est donc localement lipschitzien
   mais n'est pas lipschitzien.
   En effet, en prenant $x < y$, on a
-  \[ \frac{\left\|\frac{1}{x}-\frac{1}{y}\right\|}{\|x-y\|} = \frac{1}{xy} \]
+  \[ \frac{\norm{\frac{1}{x}-\frac{1}{y}}}{\norm{x-y}} = \frac{1}{xy} \]
   qui peut être aussi grand que l'on veut en faisant tendre $x$ vers 0.
 
   Bien que le fait que $f$ soit de classe $C_1$ implique que $f$ est
@@ -408,12 +419,12 @@ Essayons de comprendre tout cela avec des exemples.
   chaque localité.
   En effet, pour $(t,x) \in \R\times\R_{>0}$,
   en prenant $r < x$
-  on voit que $f$ est lipchitzien sur $]t-h,t+h[ \times B(x,r)$
+  on voit que $f$ est lipchitzien sur $\intervaloo{t-h}{t+h} \times B(x,r)$
   avec
   \[ L = \frac{1}{x(x-r)}. \]
 \end{myexem}
 \begin{myexem}
-  Prenons $\Omega = \R\times\R$ et $f:\Omega\to\R$ définit par
+  Prenons $\Omega = \R\times\R$ et $f\colon \Omega\to\R$ défini par
   \[
     f(t,x) =
     \begin{cases}
@@ -424,37 +435,37 @@ Essayons de comprendre tout cela avec des exemples.
   Ici $f$ n'est pas continue donc pas dérivable ni localement lipschitzien
   donc pas lipschitzien non plus.
   En effet, pour $x = 0$, prendre $r$ aussi petit que l'on veut ne change rien,
-  en prenant $y$ suffisamment proche de $x$, on a $\|1\|/\|x-y\|$,
+  en prenant $y$ suffisamment proche de $x$, on a $\norm{1}/\norm{x-y}$,
   aussi grand que l'on veut.
 \end{myexem}
 \begin{myexem}
   \label{ex:tabsx}
-  Prenons $\Omega = \R\times\R$ et $f:\Omega\to\R$ définit par
+  Prenons $\Omega = \R\times\R$ et $f\colon \Omega\to\R$ défini par
   \[
-    f(t,x) = t|x|.
+    f(t,x) = t\abs{x}.
   \]
   Ici, bien que $f$ ne soit pas dérivable si $t \neq 0$,
   $f$ est bien localement lipschitzien
   mais n'est pas lischitzienne.
   En effet, en prenant sans perte de généralité $x < y$, on a,
   si $x$ et $y$ sont de même signe
-  \[ \frac{\|t|x| - t|y|\|}{\|x-y\|} = |t| \]
+  \[ \frac{\norm{t\abs{x} - t\abs{y}}}{\norm{x-y}} = \abs{t} \]
   et s'il sont de signe opposé (alors $y \geq 0$ et $x \leq 0$ car $x < y$)
-  \[ \frac{\|t|x| - t|y|\|}{\|x-y\|}
-  = |t|\frac{|x|+|y|}{|x|+|y|} = |t| \]
+  \[ \frac{\norm{t\abs{x} - t\abs{y}}}{\norm{x-y}}
+  = \abs{t}\frac{\abs{x}+\abs{y}}{\abs{x}+\abs{y}} = \abs{t} \]
   On voit que si on ne restreint pas $t$, on ne trouvera pas
   de $L$, $f$ n'est donc pas lipschitzien.
-  Par contre, si on avait pris $\Omega = [-1;1]\times\R$,
+  Par contre, si on avait pris $\Omega = \intervalcc{-1}{1} \times\R$,
   $f$ aurait été lipschitzien en espace car on aurait pu prendre $L = 1$
-  car $|t| \leq 1$ $\forall t \in [-1;1]$.
+  car $\abs{t} \leq 1$ $\forall t \in \intervalcc{-1}{1}$.
 
   $f$ est de toute façon localement lipschitzien car pour tout
-  $(t,x) \in \R^2$, $f$ est lipschitzien sur $]t-h,t+h[ \times B(x,r)$ avec
-  $L = \max(|t-h|,|t+h|)$.
+  $(t,x) \in \R^2$, $f$ est lipschitzien sur $\intervaloo{t-h}{t+h} \times B(x,r)$ avec
+  $L = \max(\abs{t-h},\abs{t+h})$.
 \end{myexem}
 \begin{myexem}
   \label{ex:sqrtx}
-  Prenons $\Omega = \R\times\R_{\geq 0}$ et $f:\Omega\to\R$ définit par
+  Prenons $\Omega = \R\times\R_{\geq 0}$ et $f\colon \Omega\to\R$ défini par
   \[
     f(t,x) = \sqrt{x}.
   \]
@@ -462,7 +473,7 @@ Essayons de comprendre tout cela avec des exemples.
   et donc pas lipschitzien non plus.
   En effet, pour $x < y$, en prenant $x$ et $y$ de plus en plus petits,
   on a
-  \[ \frac{\|\sqrt{x}-\sqrt{y}\|}{\|x-y\|} =
+  \[ \frac{\norm{\sqrt{x}-\sqrt{y}}}{\norm{x-y}} =
   \frac{\sqrt{y} - \sqrt{x}}{y-x} =
   \frac{\sqrt{y} - \sqrt{x}}{(\sqrt{y} - \sqrt{x})(\sqrt{y} + \sqrt{x})}
   = \frac{1}{\sqrt{x}+\sqrt{y}} \]
@@ -493,12 +504,12 @@ Si $\Omega$ est convexe, localement lipschitzien implique continu.
 On a alors deux théorèmes.
 Un pour l'unicité locale et un pour l'unicité globale.
 Le théorème de l'unicité globale est en fait strictement plus
-fort que ceui de l'unicité locale.
+fort que celui de l'unicité locale.
 En effet, pour l'unicité globale, on demande juste un $\Omega$ ouvert
 alors que pour l'unicité locale, on demande un
-$\Omega=]t_0-h,t_0+h[ \times B(u_0,r)$
+$\Omega=\intervaloo{t_0-h}{t_0+h} \times B(u_0,r)$
 pour un certain $h>0$ et un certain $r>0$.
-Alors qu'on est plus restrictif pour l'unicité local,
+Alors qu'on est plus restrictif pour l'unicité locale,
 on va demander que $f$ soit \emph{continue} et \emph{lipschitzien en espace}
 alors que l'unicité globale ne demandera que d'être \emph{continu} et
 \emph{localement lipschitzien en espace}.
@@ -514,18 +525,18 @@ Elle est donc utile en théorie mais inutile en pratique.
 
 \begin{myprop}[Unicité locale]
   Soit $t_0 \in \R$, $h > 0$, $r > 0$, $u_0 \in \Rn$ et
-  $f:]t_0-h,t_0+h[ \times B(u_0,r) \to \Rn$ un champ de vecteurs
+  $f\colon \intervaloo{t_0-h}{t_0+h} \times B(u_0,r) \to \Rn$ un champ de vecteurs
   \emph{continu} et \emph{lipschitzien en espace}.
-  Si $u:]t_0-h,t_0+h[\to\Rn$ et $v:]t_0-h,t_0+h[\to\Rn$ sont des courbes
+  Si $u\colon \intervaloo{t_0-h}{t_0+h} \to\Rn$ et $v\colon \intervaloo{t_0-h}{t_0+h} \to\Rn$ sont des courbes
   intégrales de $f$ et si $u(t_0) = v(t_0)$, alors pour tout
-  $t \in ]t_0-h,t_0+h[$,
+  $t \in \intervaloo{t_0-h}{t_0+h}$,
   \[ u(t) = v(t). \]
 \end{myprop}
 \begin{myprop}[Unicité globale]
   Soit $\Omega \subseteq \R\times\Rn$ un ouvert,
-  $f: \Omega\to \Rn$ un champ de vecteurs \emph{continu},
+  $f\colon \Omega\to \Rn$ un champ de vecteurs \emph{continu},
   $I \subseteq \R$ un intervalle ouvert.
-  Soient $u:I\to \Rn$ et $v:I \to \Rn$ deux courbes intégrales de $f$.
+  Soient $u\colon I\to \Rn$ et $v\colon I \to \Rn$ deux courbes intégrales de $f$.
   Si $f$ est \emph{localement lipschitzien} en espace
   et s'il existe $t_0 \in I$
   tel que $u(t_0) = v(t_0)$, alors pour tout $t \in I$,
@@ -539,62 +550,62 @@ En effet, lorsqu'on a une solution,
 on pourrait très bien la tronquer et avoir toujours une solution.
 On va donc définir une \emph{courbe intégrale maximale} comme une courbe
 qu'on ne peut plus étendre.
-Si par exemple on dit que $u:I\to\R$ où $I = ]t_1,t_2[$
+Si par exemple on dit que $u\colon I\to\R$ où $I = \intervaloo{t_1}{t_2}$
 est une courbe intégrale maximale,
 soit $t_1 = -\infty$, soit $\lim_{t\to t_1} u(t) = \pm\infty$.
 On remarque aussi que $I$ doit être ouvert, en effet, si $I$ est fermé en
-$t_2$ par exemple, $u$ ne peut pas être maximale car si elle est définit en
-$t_2$, c'est qu'on explose pas encore et donc qu'on peut agrandir $I$
+$t_2$ par exemple, $u$ ne peut pas être maximale car si elle est définie en
+$t_2$, c'est qu'on n'explose pas encore et donc qu'on peut agrandir $I$
 à sa droite.
 
 Il y a cependant une exception à ça quand $f$ n'est pas défini sur tout
-$\mathbb{R}\times\mathbb{R}^n$.
+$\R \times \Rn$.
 En effet, soit $\Omega$ le domaine de définition de $f$, on peut dire
-qu'aux extrémitées de $I$, $(t,u(t))$ sort de $\Omega$, c'est à dire par
-exemple si $\Omega = ]0,\infty[ \times \mathbb{R}^n$ qu'à l'extrémité
+qu'aux extrémités de $I$, $(t,u(t))$ sort de $\Omega$, c'est-à-dire par
+exemple si $\Omega = \intervaloo{0}{\infty} \times \Rn$ qu'à l'extrémité
 gauche de $I$, $u$ n'est pas obligé d'exploser.
-Si par contre $\Omega = \mathbb{R} \times \mathbb{R}_+$,
+Si par contre $\Omega = \R \times \R_{\ge 0}$,
 $u$ n'est pas obligé d'exploser non plus, il suffit qu'il devienne nul.
 
-Un théorème nous garanti que si dans
+Un théorème nous garantit que si dans
 un $\Omega \subseteq \R\times\Rn$, on a $f$ qui est \emph{continue}
-et \emph{localement lipschitzien},
+et \emph{localement lipschitzienne},
 alors si pour un certain $(t_0, u_0) \in \Omega$, on impose
 $u(t_0) = u_0$, on est non seulement sûr de trouver un courbe intégrale
 maximale mais en plus elle est unique.
 Ce n'est pas la même unicité que celle garantie par l'unicité globale car
-ici, on garanti aussi qu'il y a une seul interval $I$ pour lequel $u$
+ici, on garantit aussi qu'il y a une seul intervalle $I$ pour lequel $u$
 est une courbe intégrale maximale et $u(t_0) = u_0$.
 
 Voyons maintenant comment déterminer si une fonction $u$ est une
 courbe intégrale maximale.
-Une fonction $u:I\to\R$ est une courbe intégrale maximale
+Une fonction $u\colon I\to\R$ est une courbe intégrale maximale
 si et seulement si
 $I$ est un intervalle \emph{ouvert non vide} et que,
 pour tout compact $K \subseteq \Omega$,
 \begin{align*}
-  \sup\{t \in I: (t, u(t)) \in K\} & \in I\\
-  \inf\{t \in I: (t, u(t)) \in K\} & \in I.
+  \sup\{t \in I\colon (t, u(t)) \in K\} & \in I\\
+  \inf\{t \in I\colon (t, u(t)) \in K\} & \in I.
 \end{align*}
 
 On remarque tout de suite l'importance d'imposer que $I$ soit ouvert
-car s'il est fermé, les deux inclusions sont triviallement respectées
+car s'il est fermé, les deux inclusions sont trivialement respectées
 alors que $u$ ne peut pas être maximale avec un $I$ fermé.
 
-Il faut comprendre ce théorème comme une manière et rigoureuse de dire que
-$u$ explose aux deux bornes ouverte de $I$.
+Il faut comprendre ce théorème comme une manière rigoureuse de dire que
+$u$ explose aux deux bornes ouvertes de $I$.
 En effet, si $I$ explose à droite de $I$,
-quelque soit le compact qu'on prend, on coupera toujours $u(t)$ pour un
+quel que soit le compact qu'on prend, on coupera toujours $u(t)$ pour un
 $t < t_2$, en effet, on tend vers l'infini en $t_2$ et c'est impossible
 pour un compact de ne pas intercepter cette asymptote.
 
-Par contre, si on explose pas en $t_2$, un compact bien choisi
+Par contre, si on n'explose pas en $t_2$, un compact bien choisi
 contiendra $(t_2, \lim_{t \to t_2} u(t))$ et le suprémum sera alors $t_2$
 qui n'appartient pas à $I$ car $I$ est ouvert.
 
 \section{Stabilité}
 Dans ce chapitre, on s'intéressera uniquement aux
-champ des vecteurs $f$ indépendants du temps.
+champs de vecteurs $f$ indépendants du temps.
 On s'intéresse donc à la stabilité des solutions d'une EDO de la forme
 \begin{align*}
   u'(t) & = f(u(t))\\
@@ -618,7 +629,7 @@ suffisamment petit.
 
 Il existe une condition suffisante pour que $u_0$ soit un équilibre stable.
 Il suffit que $f$ soit \emph{localement lipschitzien} et qu'il existe
-$V \in C^1(\Omega;\R)$ tel que pour toute courbe intégrale $u:I\to\Rn$ de $f$,
+$V \in C^1(\Omega;\R)$ tel que pour toute courbe intégrale $u\colon I\to\Rn$ de $f$,
 $V \circ u$ soit \emph{décroissante} et
 que pour tout $x\in\Omega\setminus\{u_0\}$,
 $V(u_0) < V(x)$.
@@ -640,7 +651,7 @@ pour que $u_0$ soit un équilibre asymptotiquement stable.
 C'est d'ailleurs la même que pour que ce soit un équilibre stable
 sauf qu'on exige une décroissance stricte.
 Il suffit que $f$ soit \emph{localement lipschitzien} et qu'il existe
-$V \in C^1(\Omega;\R)$ tel que pour toute courbe intégrale $u:I\to\Rn$
+$V \in C^1(\Omega;\R)$ tel que pour toute courbe intégrale $u\colon I\to\Rn$
 \emph{dans} $\Omega \setminus \{u_0\}$ de $f$,
 $V \circ u$ soit \emph{strictement décroissante} et
 que pour tout $x \in \Omega \setminus \{u_0\}$,
@@ -660,7 +671,7 @@ Si $f$ est \emph{localement lipschitzien},
 que $f(u_0) = 0$ et que $f$ est dérivable
 en $u_0$.
 On peut analyser la stabilité de $u_0$ à l'aide de la Jacobienne de $f$
-en $u_0$ $Df(u_0)$ (aussi notée $Jf(u_0)$).
+en $u_0$, $Df(u_0)$ (aussi notée $Jf(u_0)$).
 
 Soient $\lambda_i$ les valeurs propres de $Df(u_0)$.
 \begin{itemize}
@@ -669,18 +680,20 @@ Soient $\lambda_i$ les valeurs propres de $Df(u_0)$.
   \item Si $\exists i$ $\Re(\lambda_i) > 0$, $u_0$
     est un équilibre instable;
   \item Si $\forall i$ $\Re(\lambda_i) \leq 0$ et que $\forall i$ tel que
-    $\Re(\lambda_i) = 0$, $m_g(\lambda_i) = m_a(\lambda_i)$,
+    $\Re(\lambda_i) = 0$, $m_{\textnormal{g}}(\lambda_i) =
+    m_{\textnormal{a}}(\lambda_i)$,
     $u_0$ est un équilibre stable;
   \item Si $\forall i$ $\Re(\lambda_i) \leq 0$ et que $\exists i$ tel que
-    $\Re(\lambda_i) = 0$, où $m_g(\lambda_i) < m_a(\lambda_i)$,
+    $\Re(\lambda_i) = 0$, où $m_{\textnormal{g}}(\lambda_i) <
+    m_{\textnormal{a}}(\lambda_i)$,
     $u_0$ est un équilibre instable.
 \end{itemize}
 
 Les deux premiers items sont sûrs mais \emph{pas les deux suivants}.
 En effet, comme $f$ est localement lipschitz et continu (car dérivable),
 on sait qu'il existe une solution mais pas nécessairement qu'elle est maximale
-sur $\mathbb{R}$ or la stabilité recquiert
-que $u$ soit défini sur $[0,\infty[$.
+sur $\R$ or la stabilité recquiert
+que $u$ soit défini sur $\intervalco{0}{\infty}$.
 
 \section{Problèmes aux limites}
 Un problème aux limites est un problème dans lequel,
@@ -690,10 +703,10 @@ on cherche une fonction $u$ qui satisfasse des conditions initiales
 
 C'est une EDO de la forme
 \begin{align*}
-  u'(t) & = A(t)[u(t)] + f(t) & \forall t \in [a,b]\\
-  B_a[u(a)] & = B_b[u(b)]
+  u'(t) & = A(t)[u(t)] + f(t) & \forall t \in \intervalcc{a}{b}\\
+  B_{\textnormal{a}}[u(a)] & = B_{\textnormal{b}}[u(b)]
 \end{align*}
-où $f:[a,b]\to\Rn$, $A \in C([a,b];\Rn)$ et $B_a,B_b \in \lin(\Rn,\R^p)$.
+où $f\colon \intervalcc{a}{b}\to\Rn$, $A \in C(\intervalcc{a}{b};\Rn)$ et $B_{\textnormal{a}},B_{\textnormal{b}} \in \lin(\Rn,\R^p)$.
 
 On va maintenant voir une condition nécessaire et suffisante pour
 l'existence et l'unicité.
@@ -701,15 +714,15 @@ l'existence et l'unicité.
 Pour qu'il existe une fonction $u$,
 il faut et il suffit d'imposer une condition sur $f$.
 C'est à dire que
-\[ \int_a^b (v(s)|f(s)) \dif s = 0. \]
+\[ \int_a^b \la v(s),f(s)\ra \dif s = 0. \]
 pour tout $v$ tels que
 \begin{align*}
-  v'(t) & = -A(t)^*[v(t)] + f(t) && \forall t \in [a,b]\\
-  (\alpha|v(a)) & = (\beta|v(b)) &&
-  \forall \alpha,\beta \in \Rn | B_a[\alpha] = B_b[\beta]
+  v'(t) & = -A(t)^*[v(t)] + f(t) && \forall t \in \intervalcc{a}{b}\\
+  \la \alpha,v(a)\ra & = \la \beta,v(b)\ra &&
+  \forall \alpha,\beta \in \Rn \suchthat B_{\textnormal{a}}[\alpha] = B_{\textnormal{b}}[\beta]
 \end{align*}
-où $A(t)^*$ est la  matrice adjointe de $A$ c'est à dire la matrice telle
-que $(A(t)^*x|y) = (x|A(t)y)$ pour tout $x,y \in \Rn$.
+où $A(t)^*$ est la matrice adjointe de $A$ c'est à dire la matrice telle
+que $\la A(t)^*x, y\ra = \la x,A(t)y \ra$ pour tout $x,y \in \Rn$.
 
 \subsection{Unicité}
 Pour s'assurer qu'il existe au plus une fonction $u$,
@@ -760,56 +773,56 @@ Les colonnes de $P$ sont donc les vecteurs $v_1, \dots, v_n$.
 
 Cette propriété ne marche pas pour n'importe quelle matrice,
 elle nécessite qu'on puisse trouver une base composée de vecteurs propres.
-Une matrice pour qui ça marche est dite \emph{diagonalisable}.
+Une matrice pour laquelle ça marche est dite \emph{diagonalisable}.
 Cette tâche qui semble assez difficile est facilitée par le fait qu'une
-famille de vecteurs propres de valeurs propres différents est toujours
+famille de vecteurs propres de valeurs propres différentes est toujours
 libre.
 De plus, on voit qu'on sait trouver les valeurs propres en trouvant les
 racines du polynôme en $\lambda$ formé par $\det(A - \lambda I)$.
 Le théorème fondamental de l'algèbre nous assûre malheureusement
 pas qu'il y en a $n$ mais juste que la somme des multiplicités
-\[ \sum m_a(\lambda_i) = n. \]
+\[ \sum m_{\textnormal{a}}(\lambda_i) = n. \]
 
 Pour chaque valeur propre $\lambda_i$,
-si on arrivait à trouver $m_a(\lambda_i)$ vecteurs propres linéairement
+si on arrivait à trouver $m_{\textnormal{a}}(\lambda_i)$ vecteurs propres linéairement
 indépendants, on serait sauvé.
 On a vu que les vecteurs propres sont les vecteurs appartenant à
 $\ker(A - \lambda_iI)$.
 Le nombre de vecteurs propres linéairement indépendants est donc
-$m_g(\lambda_i) \eqdef \newnull(A-\lambda_iI)$.
+$m_{\textnormal{g}}(\lambda_i) \eqdef \newnull(A-\lambda_iI)$.
 
 On sait que si $\lambda_i$ est une valeur propre,
-\[ 1 \leq m_g(\lambda_i) \leq m_a(\lambda_i). \]
+\[ 1 \leq m_{\textnormal{g}}(\lambda_i) \leq m_{\textnormal{a}}(\lambda_i). \]
 Ça nous apporte une bonne et une mauvaise nouvelle
 \begin{itemize}
-  \item La bonne c'est que si $m_a(\lambda_i) = 1$,
-    on sait que $m_g(\lambda_i) = 1$ donc si toutes les valeurs propres
+  \item La bonne c'est que si $m_{\textnormal{a}}(\lambda_i) = 1$,
+    on sait que $m_{\textnormal{g}}(\lambda_i) = 1$ donc si toutes les valeurs propres
     sont différentes, $A$ est diagonalisable.
-  \item La mauvaise c'est que comme $m_g(\lambda_i) \leq m_a(\lambda_i)$,
-    si $m_g(\lambda_i) < m_a(\lambda_i)$, ça sera impossible qu'une
+  \item La mauvaise c'est que comme $m_{\textnormal{g}}(\lambda_i) \leq m_{\textnormal{a}}(\lambda_i)$,
+    si $m_{\textnormal{g}}(\lambda_i) < m_{\textnormal{a}}(\lambda_i)$, ça sera impossible qu'une
     autre valeur propre vienne compenser pour faire
-    \[ \sum m_g(\lambda_i) = n. \]
+    \[ \sum m_{\textnormal{g}}(\lambda_i) = n. \]
     Mais ça permet de dire qu'une matrice est diagonalisable si et seulement
-    si $m_g(\lambda_i) = m_a(\lambda_i)$ $\forall i$.
+    si $m_{\textnormal{g}}(\lambda_i) = m_{\textnormal{a}}(\lambda_i)$ $\forall i$.
 \end{itemize}
 
 \subsection{Les valeurs propres généralisées à la rescousse}
-On a donc une problème avec les $\lambda_i$ pour qui
-$m_a(\lambda_i) > 1$ et que $m_g(\lambda_i) < m_a(\lambda_i)$.
+On a donc une problème avec les $\lambda_i$ pour lesquels
+$m_{\textnormal{a}}(\lambda_i) > 1$ et que $m_{\textnormal{g}}(\lambda_i) < m_{\textnormal{a}}(\lambda_i)$.
 Notre rêve de trouver $P$ inversible et $D$ diagonale
 telles que $A = PDP^{-1}$ tombe alors un peu à l'eau mais
 on peut toujours s'en sortir pour exprimer $Av$ sans produit matriciel
 une fois qu'on a exprimé $v$ dans une base de vecteurs propres.
 
-Seulement, comme $\sum m_g(\lambda_i) < n$, on ne trouvera pas
+Seulement, comme $\sum m_{\textnormal{g}}(\lambda_i) < n$, on ne trouvera pas
 de base de vecteurs propres, il faut donc aller chercher plus loin
-pour les $\lambda_i$ tels que $m_g(\lambda_i) < m_a(\lambda_i)$.
+pour les $\lambda_i$ tels que $m_{\textnormal{g}}(\lambda_i) < m_{\textnormal{a}}(\lambda_i)$.
 On va en effet allez chercher non plus seulement dans $\ker(A - \lambda I)$
-mais aussi dans $\ker(A - \lambda I)^2$ et si c'est pas suffisant dans
+mais aussi dans $\ker(A - \lambda I)^2$ et si ce n'est pas suffisant dans
 $\ker(A - \lambda I)^3$ et ainsi de suite.
 On dit donc que $\lambda_i$ est une valeur propre \emph{généralisée}
 d'ordre $k$ si $k$ est le plus petit naturel tel que
-$\newnull(A - \lambda_i I)^k = m_a(\lambda_i)$.
+$\newnull(A - \lambda_i I)^k = m_{\textnormal{a}}(\lambda_i)$.
 Les vecteurs propres généralisés sont alors les vecteurs de
 $\ker(A - \lambda_i I)^k$.
 

--- a/src/q4/edo-MAT1223/summary/edo-MAT1223-summary.tex
+++ b/src/q4/edo-MAT1223/summary/edo-MAT1223-summary.tex
@@ -20,7 +20,7 @@ $I \subseteq \R $ un intervalle et $t \in I$.
 Dans cette section, $A$ sera une matrice à coefficients constants.
 
 On remarque que si $u$ et donc $A$ sont scalaires, la solution est
-\[ u(t) = e^{At}u(0) = \lim_{m\to\infty} \sum_{k=0}^m\frac{(At)^k}{k!}u(0) \]
+\[ u(t) = \e^{At}u(0) = \lim_{m\to\infty} \sum_{k=0}^m\frac{(At)^k}{k!}u(0) \]
 d'où l'intuition qui semble parachutée de la solution pour $u(t)$ vectoriel
 \[ u(t) = \lim_{m\to\infty} \sum_{k=0}^m\frac{(tA)^k[u(0)]}{k!}. \]
 
@@ -34,15 +34,15 @@ Seulement, il nous faut s'assurer de deux choses
 
 On peut démontrer que c'est bien le cas.
 On définit alors l'\emph{exponentielle d'opérateur}
-\[ e^{A}[v] \eqdef \lim_{k\to\infty} \sum_{i=0}^k \frac{A^i[v]}{i!}. \]
+\[ \e^{A}[v] \eqdef \lim_{k\to\infty} \sum_{i=0}^k \frac{A^i[v]}{i!}. \]
 Il faut faire attention à ne pas se laisser tromper par la notation.
 Ce n'est pas un exponentielle comme les autres, on a pas toutes les propriétés
 des exponentielles classiques.
-Par exemple, en général, $e^{A + B} \neq e^A \circ e^{B}$.
+Par exemple, en général, $\e^{A + B} \neq \e^A \circ \e^{B}$.
 On a par contre
 \begin{align*}
-  \fdif{}{t}(e^{tA}[v]) & = e^{tA} \circ A[v]\\
-  A \circ e^A & = e^A \circ A.
+  \fdif{}{t}(\e^{tA}[v]) & = \e^{tA} \circ A[v]\\
+  A \circ \e^A & = \e^A \circ A.
 \end{align*}
 
 %faudrait enlever les s à propriétés en général
@@ -55,10 +55,10 @@ On a par contre
     u'(t) & = A[u(t)]\\
     u(t_0) & = u_0
   \end{align*}
-  cette solution est $u(t) = e^{(t-t_0)A}[u_0]$ et est \emph{unique}.
+  cette solution est $u(t) = \e^{(t-t_0)A}[u_0]$ et est \emph{unique}.
 \end{myprop}
 Pour $u'(t) = A[u(t)] + b(t)$, la solution devient
-\[ u(t) = e^{(t-t_0)A}[u_0] + \int_{t_0}^t e^{(t-s)A}[b(s)]\dif s. \]
+\[ u(t) = \e^{(t-t_0)A}[u_0] + \int_{t_0}^t \e^{(t-s)A}[b(s)]\dif s. \]
 
 On remarque que l'exponentielle d'opérateurs se simplifie grandement
 pour les valeurs propres généralisées (voir l'annexe~\ref{ann:vpg}) de $A$.
@@ -66,8 +66,8 @@ pour les valeurs propres généralisées (voir l'annexe~\ref{ann:vpg}) de $A$.
 En effet, si $\lambda$ est une valeur propre généralisée d'ordre $k$
 \emph{et que $v$ est un vecteur propre généralisé de valeur propre $\lambda$},
 on a
-\[ e^{tA}[v] =
-e^{\lambda t} \sum_{i=0}^{k-1}\frac{t^i}{i!}(A-\lambda I)^i[v]. \]
+\[ \e^{tA}[v] =
+\e^{\lambda t} \sum_{i=0}^{k-1}\frac{t^i}{i!}(A-\lambda I)^i[v]. \]
 
 C'est un résultat assez intéressant.
 En effet, comme l'EDO est linéaire, si on a une condition initiale
@@ -75,8 +75,8 @@ $v$ qui n'est pas un vecteur propre, on pourra la décomposer en une somme
 de vecteurs propres $v_i$ à l'aide de Gram-Schmidt
 \footnote{Voir la synthèse de Mathématique Q2.}. % TODO biblio
 On pourra alors tout simplement écrire
-\[ e^{tA}[v] =
-\sum_{i=1}^m e^{\lambda_i t}
+\[ \e^{tA}[v] =
+\sum_{i=1}^m \e^{\lambda_i t}
 \sum_{j=0}^{k_i-1}\frac{t^j}{j!}(A-\lambda_i I)^j[v_i] \]
 où $\lambda_1, \ldots, \lambda_m$ sont les $m$ valeurs propres généralisées
 de degré $k_i$ où $\sum_{i=1}^m k_i = n$.
@@ -85,8 +85,8 @@ La projection des $v$ en vecteurs propres $v_i$ peut être modélisé
 par un produit matriciel $v_i = P_i v$.
 On peut alors mettre en évidence $v$ dans la formule précédente et en posant
 $B_{i,j} = (A-\lambda_i I)^j P_i$, on a
-\[ e^{tA} =
-\sum_{i=1}^m e^{\lambda_i t}
+\[ \e^{tA} =
+\sum_{i=1}^m \e^{\lambda_i t}
 \sum_{j=0}^{k_i-1}\frac{t^j}{j!}B_{i,j}. \]
 On pose $B_{i,j}$ ici pour mettre en évidence le fait que le plus important,
 c'est qu'il existe une certaine matrice $B_{i,j}$,
@@ -96,11 +96,11 @@ existe.
 En effet, un des corrolaires importants de cet identité est que
 si $\sigma > \Re(\lambda)$ $\forall \lambda \in \spec A$,
 il existe $C \geq 1$ tel que
-\[ \|e^{tA}\| \leq Ce^{\sigma t}. \]
+\[ \|\e^{tA}\| \leq C\e^{\sigma t}. \]
 C'est une inégalité assez utile,
 ça permet par exemple de dire que si
 $\Re(\lambda) < 0$, $\forall \lambda \in \spec(A)$,
-$\lim_{t\to 0} e^{tA} = 0$.
+$\lim_{t\to 0} \e^{tA} = 0$.
 % FIXME ref stabilité ?
 
 \section{EDO à coefficients variables}

--- a/src/q5/stat-FSAB1105/summary/stat-FSAB1105-summary.tex
+++ b/src/q5/stat-FSAB1105/summary/stat-FSAB1105-summary.tex
@@ -2,7 +2,7 @@
 
 \def\Perp{\perp\!\!\!\perp}
 \newcommand{\E}{\mathbb{E}}
-\newcommand{\N}{\mathcal{N}}
+\renewcommand{\N}{\mathcal{N}}
 \DeclareMathOperator{\var}{\mathbb{V}ar}
 \DeclareMathOperator{\cov}{Cov}
 \DeclareMathOperator{\bias}{Bias}
@@ -43,12 +43,12 @@ point du \textit{sample space}.
 
 \begin{mydef}[Probabilité]
 A chaque évènement $A$ de $S$ on associe un nombre
-$P(A)$, appelée la probabilité de $A$, tel que 
+$P(A)$, appelée la probabilité de $A$, tel que
 \begin{itemize}
 	\item $P(A) \geq 0$ ;
 	\item $P(S) = 1$ ;
 	\item Si ${A}_i$ sont incompatibles (mutuellement exclusifs)
-	\[ P(\cup_iA_i) = \sum_i P(A_i). \]  
+	\[ P(\cup_iA_i) = \sum_i P(A_i). \]
 \end{itemize}
 \end{mydef}
 
@@ -74,7 +74,7 @@ de remplir $r$ positions avec $n$ objets distincts
 est noté $P^n_r$ et est donné par
 
 \[ P^n_r = \frac{n!}{(n-r)!}.\]
-\end{mytheo} 
+\end{mytheo}
 
 \begin{mytheo}
 Le nombre de façon de partitionner $n$ objets distincts
@@ -142,7 +142,7 @@ de $S$.
 \begin{mytheo}
 Si ${B_1, B_2 \dots B_k}$ est une partition de $S$ tel
 que $P(B_i) > 0$ $\forall i$, alors pour chaque évènement $A$
-\[ P(A) = \sum_{i=1}^k P(A \cap B_i) = 
+\[ P(A) = \sum_{i=1}^k P(A \cap B_i) =
 \sum_{i=1}^k P(A|B_i)P(B_i). \]
 \end{mytheo}
 
@@ -335,8 +335,8 @@ elle détermine entièrement la distribution en utilisant par exemple \eqref{eq:
 
 \subsection{Minimum et maximum de variables aléatoires indépendantes}
 Soient $Y_1, Y_2, \dots, Y_n$ des variables aléatoires indépendantes de fonction
-de répartition $F(y)$ et de densité de probabilité $f(y)$. 
-Soient également $Y_{(1)} = \min(Y_1, Y_2, \dots, Y_n)$ et 
+de répartition $F(y)$ et de densité de probabilité $f(y)$.
+Soient également $Y_{(1)} = \min(Y_1, Y_2, \dots, Y_n)$ et
 $Y_{(n)} = \max(Y_1, Y_2, \dots, Y_n)$. En utilisant la méthode de la
 fonction de répartition, on trouve
 \[ g_{(n)}(y) = nF^{n-1}(y)f(y) \]
@@ -495,7 +495,7 @@ On va donc plutôt résoudre
 
 Cette méthode est \emph{pertinente} et \emph{équivariante}.
 Équivariante signifie que
-``Si $\hat{\theta}$ est l'estimateur par maximum de vraissemblance de $\theta$ 
+``Si $\hat{\theta}$ est l'estimateur par maximum de vraissemblance de $\theta$
 et $g$ une fonction bijective, alors $g(\hat{\theta})$ est l'estimateur par maximum
 de vraissemblance de $g(\theta)$.''
 

--- a/src/q6/prostoch-INMA1731/summary/prostoch-INMA1731-summary.tex
+++ b/src/q6/prostoch-INMA1731/summary/prostoch-INMA1731-summary.tex
@@ -5,7 +5,7 @@
 \def\Perp{\perp\!\!\!\perp}
 
 \newcommand{\E}{\mathbb{E}}
-\newcommand{\N}{\mathcal{N}}
+\renewcommand{\N}{\mathcal{N}}
 \DeclareMathOperator{\var}{\mathbb{V}ar}
 \DeclareMathOperator{\cov}{Cov}
 \DeclareMathOperator{\bias}{Bias}


### PR DESCRIPTION
Fix the multiplicity of myprop in eplcommon; fixed some more formatting
in edo (didn't take the class though so can't say that much about the
math); found an issue in probastat and prostoch with the \N command.
Since I redefined it earlier to denote the set of natural numbers, it
became a doubly-defined command which LaTeX can't deal with. The issue
might reappear in other documents, will have to scourge the repo to find
out...