### PR TITLE
[FSAB1302] Fix looseness error

### DIFF
--- a/src/q3/chimie-FSAB1302/exam/2015/Janvier/All/chimie-FSAB1302-exam-2015-Janvier-All.tex
+++ b/src/q3/chimie-FSAB1302/exam/2015/Janvier/All/chimie-FSAB1302-exam-2015-Janvier-All.tex
@@ -264,8 +264,8 @@ Le mécanisme réactionnel suivant est alors proposé:
       condition de justifier les choix que l'on fait.
 
      \begin{center}
-          \begin{endiagram}[scale=1.7,looseness=0.7]
-               \ENcurve{3, 6, 3.9, 9, 3.9, 7.5[-.5], 0}
+          \begin{endiagram}[scale=1.7]
+               \ENcurve[looseness=0.7]{3, 6, 3.9, 9, 3.9, 7.5[-.5], 0}
                \ShowEa[
                from = {(N1-1) to (N1-2)},
                label = $E_{\textnormal{a,}1}$


### PR DESCRIPTION
@Peiffap J'ai une erreur disant que looseness n'est pas une option valide avec la dernière version de endiagram (i.e. v0.1d) et avec ce changement (qui correspond à comment looseness est utilisé dans [la doc](http://ctan.triasinformatica.nl/macros/latex/contrib/endiagram/endiagram_en.pdf)) ça marche. Chouette diagramme en tout cas :)