### PR TITLE
Removing CC-BY-SA license for tests and exercises solutions

### DIFF
--- a/src/eplexercises.cls
+++ b/src/eplexercises.cls
@@ -1,6 +1,17 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesClass{eplexercises}[2015/01/14 EPL exercises class]
 
+% We do not license exercises under CC-BY-SA since part of
+% the documents are work of professors.
+
+% I need to pass license=none to eplbase so I cannot just do
+% \LoadClassWithOptions because it ignores \PassOptionsToClass.
+% I need to pass every option manually with the 2 following lines
+% and then use \LoadClass
+\DeclareOption*{\PassOptionsToClass{\CurrentOption}{../../../../../../eplbase}}
+\ProcessOptions\relax
+\PassOptionsToClass{license=none}{../../../../../../eplbase}
+
 \LoadClassWithOptions{../../../eplbase}
 
 \IfLanguageName{english}{

--- a/src/epltest.cls
+++ b/src/epltest.cls
@@ -1,6 +1,17 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesClass{epltest}[2015/03/06 EPL test class]
 
+% We do not license tests under CC-BY-SA since part of
+% the documents are work of professors.
+
+% I need to pass license=none to eplbase so I cannot just do
+% \LoadClassWithOptions because it ignores \PassOptionsToClass.
+% I need to pass every option manually with the 2 following lines
+% and then use \LoadClass
+\DeclareOption*{\PassOptionsToClass{\CurrentOption}{../../../../../../eplbase}}
+\ProcessOptions\relax
+\PassOptionsToClass{license=none}{../../../../../../eplbase}
+
 \LoadClassWithOptions{../../../../../../epleval}
 
 \IfLanguageName{english}{


### PR DESCRIPTION
As it contains work by professors and teaching assistants.