### PR TITLE
Fixes to algo summary

### DIFF
--- a/src/eplcode.sty
+++ b/src/eplcode.sty
@@ -24,7 +24,7 @@
   commentstyle=\color{gray}=small,
   stringstyle=\color{dkgreen},
   %backgroundcolor=\color{gray!10},
-  %tabsize=2,
+  tabsize=8, % Thank you Papa Torvalds
   rulecolor=\color{black!30},
   %title=\lstname,
   breaklines=true,

--- a/src/eplcode.sty
+++ b/src/eplcode.sty
@@ -24,7 +24,7 @@
   commentstyle=\color{gray}=small,
   stringstyle=\color{dkgreen},
   %backgroundcolor=\color{gray!10},
-  tabsize=8, % Thank you Papa Torvalds
+  %tabsize=8, % Thank you Papa Torvalds
   rulecolor=\color{black!30},
   %title=\lstname,
   breaklines=true,

--- a/src/eplcommon.sty
+++ b/src/eplcommon.sty
@@ -1,5 +1,5 @@
 \NeedsTeXFormat{LaTeX2e}[1994/06/01]
-\ProvidesPackage{eplcommon}[2018/06/05 EPL common package]
+\ProvidesPackage{eplcommon}[2018/07/23 EPL common package]
 
 % Always prettier with Small Capitals
 % But use this command so if the definition of `pretty' changes
@@ -65,6 +65,8 @@
 
 % Complexity
 \newcommand{\bigoh}{\mathcal{O}}
+\newcommand{\bigtheta}{\Theta}
+\newcommand{\bigomega}{\Omega}
 % Equal by definition
 \newcommand{\eqdef}{\triangleq}
 % Equivalent by definition
@@ -96,6 +98,7 @@
 \newtheorem{mydef}{Definition}
 \newtheorem{mynota}[mydef]{Notation}
 \newtheorem{myprop}[mydef]{Property}
+\newtheorem{mypropo}[mydef]{Proposition}
 \newtheorem{myrem}[mydef]{Remark}
 \newtheorem{myform}[mydef]{Formula}
 \newtheorem{mycorr}[mydef]{Corollary}
@@ -113,8 +116,9 @@
 \newtheorem{mydef}{Définition}
 \newtheorem{mynota}[mydef]{Notation}
 \newtheorem{myprop}[mydef]{Propriété}
+\newtheorem{mypropo}[mydef]{Proposition}
 \newtheorem{myrem}[mydef]{Remarque}
-\newtheorem{myform}[mydef]{Formules}
+\newtheorem{myform}[mydef]{Formule}
 \newtheorem{mycorr}[mydef]{Corrolaire}
 \newtheorem{mytheo}[mydef]{Théorème}
 \newtheorem{mylem}[mydef]{Lemme}

--- a/src/eplmath.sty
+++ b/src/eplmath.sty
@@ -1,0 +1,13 @@
+\NeedsTeXFormat{LaTeX2e}[1994/06/01]
+\ProvidesPackage{eplmath}[2018/07/23 EPL math package]
+
+\makeatletter
+\DeclareRobustCommand{\genericinterval}[2]{%
+  \@ifstar{\genericinterval@star{#1}{#2}}{\genericinterval@nostar{#1}{#2}}}
+\newcommand{\genericinterval@star}[4]{\mathopen{}\mathclose{\left#1#3,#4\right#2}}
+\newcommand{\genericinterval@nostar}[4]{\mathopen{#1}#3,#4\mathclose{#2}}
+\newcommand{\intervalcc}{\genericinterval[]}
+\newcommand{\intervaloo}{\genericinterval][}
+\newcommand{\intervaloc}{\genericinterval]]}
+\newcommand{\intervalco}{\genericinterval[[}
+\makeatother

--- a/src/q4/edo-MAT1223/summary/edo-MAT1223-summary.tex
+++ b/src/q4/edo-MAT1223/summary/edo-MAT1223-summary.tex
@@ -1,22 +1,12 @@
 \documentclass[fr]{../../../eplsummary}
 
 \usepackage[SIunits]{../../../eplunits}
+\usepackage{../../../eplmath}
 
 \DeclareMathOperator{\lin}{Lin}
 \DeclareMathOperator{\spec}{spec}
 \DeclareMathOperator{\newnull}{null}
 \newcommand{\sol}{\mathcal{S}}
-
-\makeatletter
-\DeclareRobustCommand{\genericinterval}[2]{%
-  \@ifstar{\genericinterval@star{#1}{#2}}{\genericinterval@nostar{#1}{#2}}}
-\newcommand{\genericinterval@star}[4]{\mathopen{}\mathclose{\left#1#3,#4\right#2}}
-\newcommand{\genericinterval@nostar}[4]{\mathopen{#1}#3,#4\mathclose{#2}}
-\newcommand{\intervalcc}{\genericinterval[]}
-\newcommand{\intervaloo}{\genericinterval][}
-\newcommand{\intervaloc}{\genericinterval]]}
-\newcommand{\intervalco}{\genericinterval[[}
-\makeatother
 
 \hypertitle[']{\'Equations diff\'erentielles ordinaires}{4}{MAT}{1223}
 {Beno\^it Legat}

--- a/src/q5/algo-SINF1121/summary/algo-SINF1121-summary.tex
+++ b/src/q5/algo-SINF1121/summary/algo-SINF1121-summary.tex
@@ -2,236 +2,221 @@
 
 \usepackage{../../../eplcommon}
 \usepackage{../../../eplcode}
+\usepackage{../../../eplmath}
 \usepackage{wrapfig}
 \usepackage{float}
+\usepackage{multirow}
+\usepackage{subcaption}
 \lstset{language=Java, basicstyle=\rm\small\ttfamily, tabsize=2}
 
-\hypertitle[']{Algorithms and data structures}{5}{SINF}{1121}
-{Antoine Paris\and Sylvain Ramelot\and Charles Momin}
-{Pierre Schauss}
+\hypertitle[']{Algorithmics and data structures}{5}{SINF}{1121}
+{Charles Momin\and Antoine Paris\and Gilles Peiffer\and Sylvain Ramelot}
+{Pierre Schaus}
 
 % TODO
-% - translate everything to english
 % - improve a lot sections on basic data structures and sorting
-% - add a subsection on trie in "Strings"
 % - complete a bit subsection on data compression
-% - add "Graphs" section
 
-\section{Piles, files et listes chaînées}
-\subsection{Listes chaînées}
-\paragraph{Définition} Une \textit{liste chaînée}
-est une structure de données récursive qui est soit
-vide (\textit{null}) soit une référence vers un
-noeud contenant une donnée générique et une référence
-vers une liste chaînée.
+\section{Stacks, queues and linked lists}
+\begin{mydef}[Linked list]
+	A \emph{linked list} is a recursive data structure which is either empty
+	(\emph{null}) or a reference to another node containing data and a
+	reference to a linked list.
+\end{mydef}
 
-Pour définir un noeud, on utilise une classe imbriquée :
+In order to define a node, a nested class is used:
 
-\begin{lstlisting}
-private class Node {
-	private Item item;
-	private Node next;
-}
-\end{lstlisting}
+\lstinputlisting{code/Node.java}
 
-Une liste chaînée permet, si on possède un lien vers
-le premier et le dernier élément de réaliser les
-opérations suivantes en un temps indépendant de la
-taille de la liste :
+A linked list allows, with a link to the first and last elements, to realise
+the following operations in constant time ($\bigoh(1)$):
 
 \begin{itemize}
-	\item Insérer un élément au début ;
-	\item Supprimer un élément au début ;
-	\item Insérer un élément à la fin.
+	\item inserting at the beginning;
+	\item removing an element at the beginning;
+	\item inserting an element at the end.
 \end{itemize}
 
-Pour pouvoir effectuer des insertions/suppressions
-arbitraires efficacement, il faut utiliser des listes
-doublement chaînées (chaque noeud possède deux liens,
-un dans chaque direction).
+In order to randomly insert and remove, one needs to use doubly linked lists
+(each node has two links, one in every direction).
 
-Les implémentations de \lstinline{Stack}, \lstinline{Queue}
-et \lstinline{Bag} reposent sur les listes chaînées. Grâce
-à ces dernières, l'espace mémoire requis est proportionnel
-au nombre d'items dans la collection et le temps requis
-par opération est toujours indépendant de la taille de la
-collection (ce ne serait pas le cas en utilisant des tableaux
-par exemple).
+The implementations of \lstinline{Stack}, \lstinline{Queue}
+and \lstinline{Bag} are based on linked lists. Thanks to these lists, the
+required memory space is proportional to the number of items in the collection
+and the time required per operation is always independent of the size of the
+collection (which wouldn't be the case using arrays for example).
 
 \subsection{Stack}
-Le principe de fonctionnement d'une stack est illustré à la figure
-\ref{fig:stack}.
+The working principle of a stack is illustrated in \figuref{stack}.
 
 \begin{figure}[ht]
 	\centering
 	\includegraphics[scale=1.0]{img/stack.png}
-	\caption{Illustration du fonctionnement d'une Stack LIFO.}
+	\caption{Illustration of the working principle of a LIFO stack.}
 	\label{fig:stack}
 \end{figure}
 
 \lstinputlisting{code/Stack.java}
 
 \subsection{Queue}
-Le principe de fonctionnement d'une queue est illustré à la figure
-\ref{fig:queue}.
+The working principle of a queue is illustrated in \figuref{queue}.
 
 \begin{figure}[ht]
 	\centering
 	\includegraphics[scale=1.0]{img/queue.png}
-	\caption{Illustration du fonctionnement d'une Queue FIFO.}
+	\caption{Illustration of the working principle of a FIFO queue.}
 	\label{fig:queue}
 \end{figure}
 
 \lstinputlisting{code/Queue.java}
 
 \subsection{Bag}
-Un bag est simplement une stack sans méthode \lstinline{pop()}.
+A bag is simply a stack without a \lstinline{pop()} subroutine.
 
-\section{Algorithmes de tri}
-Le but du jeu ici est de trier des tableaux d'items contenant
-chacun une clé en suivant un ordre bien particulier (le plus
-souvent numérique ou alphabétique). La notion de clé est inclue
-dans un mécanisme propre à Java, l'interface \lstinline{Comparable}
-(et notamment la méthode \lstinline{compareTo}).
+\section{Sorting algorithms}
+The aim of the game here is to sort arrays of items each containing a key
+according to a particular order (usually alphabetical or numerical). The notion
+of a key is included in a mechanism own to \java{}, the \lstinline{Comparable}
+interface (with for example the \lstinline{compareTo} subroutine).
 
-On distingue deux types d'algorithmes de tri, les algorithmes
-\textbf{en place} qui n'utilisent pas (ou quasi pas) de mémoire
-supplémentaire et ceux qui nécessitent assez de mémoire
-supplémentaire pour garder une copie du tableau à trier en
-mémoire.
+Two types of sorting algorithms exist:
+\begin{itemize}
+	\item \textbf{in-place} algorithms, which don't (or barely) use additional
+	memory;
+	\item other sorting algorithms, which need memory to save a copy of the
+	array to be sorted in memory.
+\end{itemize}
 
-Dans les algorthimes de tri présentés dans cette section,
-on utilise le template suivant.
+For the sorting algorithms presented in this section, the following template is
+used.
 
 \lstinputlisting{code/SortTemplate.java}
 
-\subsection{Selection Sort}
-\subsubsection{Principe}
-Le tri par sélection est un des plus simple. Il fonctionne
-comme suit : premièrement, trouver l'élément le plus petit
-du tableau et l'échanger avec le premier élément, ensuite
-trouver le deuxième élément le plus petit du tableau et
-l'échanger avec le deuxième élément, et ainsi de suite.
-La traduction en Java est immédiate.
+\subsection{Selection sort}
+\subsubsection{Principle}
+Selection sort is one of the simpler sorting algorithms. It works as follows:
+first, find the smallest element of the array, and swap it with the first
+element. After that, find the second smallest element in the smaller array and
+swap it with the second element, and so on and so forth. Translating this into
+\java{} is relatively easy.
 
-\subsubsection{Implémentation}
+\subsubsection{Implementation}
 \lstinputlisting{code/Selection.java}
 
-\subsubsection{Propriétés}
-\paragraph{Le temps d'éxécution est indépendant de l'entrée}
-L'algorithme mettra autant de temps à trier à tableau déjà
-trié qu'un tableau aléatoirement ordonné.
+\subsubsection{Properties}
+\begin{myprop}[Execution time doesn't depend on input]
+	The algorithm takes the same amount of time sorting a sorted array as a
+	randomly ordered one.
+\end{myprop}
 
-\paragraph{Mouvement minimal}
-Le nombre d'échange est une fonction linéaire de la taille
-du tableau à trier ($N$ échanges sont effectués). 
+\begin{myprop}[Minimal movement]
+	The number of swaps is a linear function of the size of the array ($N$
+	swaps are made).
+\end{myprop}
 
-\subsubsection{Complexité}
-Dans tous les cas $\frac{N^2}{2}$ comparaisons et $N$ échanges.
+\subsubsection{Complexity}
+There are always $\frac{N^2}{2}$ comparisons and $N$ swaps.
 
-\subsection{Insertion Sort}
-\subsubsection{Principe}
-C'est l'algorithme qu'on utilise en général pour trier
-ses cartes. On considère une carte à la fois, et on
-l'insère à sa place parmis les cartes déjà triées. La
-seule différence est qu'ici il faut faire de la place
-pour insérer l'item considéré à sa position, on doit
-donc décaler tout les items plus grand que lui d'une
-position vers la droite.
+\subsection{Insertion sort}
+\subsubsection{Principle}
+This algorithm is the one generally used to sort playing cards. Every card
+is placed where it belongs between already sorted cards. The only difference is
+that in this algorithm, there has to be a certain amount of available memory
+space to insert the item, and therefor all following items have to be moved one
+step to the right.
 
-\subsubsection{Implémentation}
+\subsubsection{Implementation}
 \lstinputlisting{code/Insertion.java}
 
-\subsubsection{Propriétés}
-Contrairement au tri par sélection, le temps d'éxécution
-du tri par insertion est dépendant de l'entrée, il est par
-exemple \textbf{excellent pour des tableaux presque triés}.
+\subsubsection{Properties}
+\begin{myprop}[Execution time depends on input (\emph{adaptive})]
+As opposed to selection sort, the exectuion time of the insertion sort
+algorithm depends on the input. For example, it is \textbf{excellent for
+substantially sorted or quite small data sets}.
+\end{myprop}
 
-C'est également une méthode correcte pour de très petits
-tableaux.
+\subsubsection{Complexity}
+In the worst case, $\frac{N^2}{2}$ comparisons and $\frac{N^2}{2}$ swaps.
 
-\subsubsection{Complexité}
-Dans le pire cas, $\frac{N^2}{2}$ comparaisons et
-$\frac{N^2}{2}$ échanges.
+\subsection{Shellsort}
+\subsubsection{Principle}
+Shellsort is just a simple extension of insertion sort. Whereas insertion sort
+only uses swaps between adjacent elements, shellsort uses swaps between
+distant elements in order to be faster.
 
-\subsection{Shell Sort}
-\subsubsection{Principe}
-Le shellsort est juste une simple extension du tri
-par insertion. Dans le tri par insertion, les échanges
-n'impliquent que des éléments adjacents, les items ne
-peuvent donc se déplacer que d'un élément à la fois.
-Le shellsort gagne en rapidité en autorisant des échanges
-d'éléments éloignés dans le tableau.
+\begin{mydef}[$h$-sorted array]
+An array is $h$-sorted when all elements separated by $h$ positions are sorted.
+\end{mydef}
 
-\paragraph{Tableau $h$-trié} un tableau $h$-trié ($h$-sorted
-array) est un tableau dont tous les éléments séparés
-de $h$ positions sont triés.
-
-\subsubsection{Implémentation}
-Concrètement, l'algorithme s'implémente en utilisant le
-tri par insertion pour obtenir successivement des 
-tableaux $h$-triés avec $h$ décroissant.
+\subsubsection{Implementation}
+Concretely, the algorithm is implemented by using insertion sort to obtain
+successive $h$-sorted arrays, with $h$ decreasing.
 
 \lstinputlisting{code/Shell.java}
 
-\subsubsection{Propriétés}
-Lorsqu'un tableau $h$-trié est $k$-trié, il reste
-$h$-trié.
+\subsubsection{Properties}
+\begin{myprop}
+When an $h$-sorted array is $k$-sorted, it stays $h$-sorted.
+\end{myprop}
 
-\subsubsection{Complexité}
-Un peu moins quadratique, $N^{\frac{4}{3}}$, $N^{\frac{5}{4}}$
-ou $N^{\frac{6}{5}}$ dans le pire cas.
+\subsubsection{Complexity}
+Slightly sub-quadratic, $\bigoh(N^{\frac{4}{3}})$,
+$\bigoh(N^{\frac{5}{4}})$ or $\bigoh(N^{\frac{6}{5}})$ in the worst case.
+The different results depend on the gap sequence used (successive values of
+$h$).
 
-\subsection{Mergesort}
-Le principe du tri par fusion est assez simple : pour trier
-un tableau, diviser le en deux moitiés, trier chaque moitié
-(récursivement) et ensuite fusionner les résultats.
+\subsection{Merge sort}
+\subsubsection{Principle}
+The working principle of merge sort is relatively simple: to sort a data set,
+divide it up into two halves, recursively sort each half and merge the results.
 
-La complexité des algorithmes de tri par fusion est
-logarithmique en $N\log N$. Le tri par fusion est
-un algorithme de tri basé sur des comparaisons
-asymptotiquement optimal (on ne peut pas faire mieux).
+\subsubsection{Complexity}
+The algorithmic complexity of merge sort algorithms is logarithmic:
+$\bigoh(n\log n)$. Merge sort is an asymptotically optimal comparison sort (all
+comparison sorts are $\bigomega(n \log n)$).
 
-Les deux implémentations du tri par fusion vues ici
-se base sur la méthode \lstinline{merge} suivante :
+The two possible implementations of merge sort use the following
+\lstinline{merge} subroutine:
 
-\lstinputlisting{code/mergeMethod.java}
+\lstinputlisting{code/MergeMethod.java}
 
-\subsubsection{Top-down mergesort}
-Ici, on divise le problème en sous-problèmes et on les résout
-récursivement. 
+\subsubsection{Top-down merge sort}
+The list is split into sublists and each sublist is sorted recursively then
+merged.
 
 \lstinputlisting{code/Merge.java}
 
 \begin{figure}[ht]
 	\centering
 	\includegraphics[scale=0.5]{img/mergesortTD.png}
-	\caption{Trace des résultats de merge pour le top-down mergesort.}
+	\caption{Trace of merge results for top-down merge sort.}
 \end{figure}
 
-\subsubsection{Bottom-up mergesort}
-Ici, on construit des petites solutions que l'on rassemble
-pour en former des plus grandes à chaque fois. 
+\subsubsection{Bottom-up merge sort}
+The list is treated as an array of sublists which are iteratively merged to
+form bigger ones.
 
 \lstinputlisting{code/MergeBU.java}
 
 \begin{figure}[ht]
 	\centering
 	\includegraphics[scale=0.5]{img/mergesortBU.png}
-	\caption{Trace des résultats de merge pour le bottom-up mergesort.}
+	\caption{Trace of merge results for bottom-up merge sort.}
 \end{figure}
 
-C'est la méthode à privilégier pour trier une liste chaînée.
+This method is preferred for sorting linked lists.
 
 \subsection{Quicksort}
-\subsubsection{Principes}
-Le tri rapide est probablement le plus utilisé, et ce pour
-les deux raisons suivantes : il est en place et s'éxécute
-en un temps proportionnel à $N \log N$.
-Il fonctionne selon le principe du \textit{diviser pour
-mieux régner}. Il partitionne le tableau en deux parties
-et les trie ensuite indépendemment comme illustré sur
-la figure \ref{fig:quicksort-overview}
+\subsubsection{Principles}
+Quicksort is probably the most used sorting algorithm, for the following reasons:
+\begin{itemize}
+	\item it is an in-place algorithm;
+	\item it has a $\bigoh(n \log n)$ complexity.
+\end{itemize}
+
+Quicksort is a \textit{divide and conquer} algorithm. It first divides a large
+array into two smaller sub-arrays. It can then recursively sort the sub-arrays
+as in \figuref{quicksort-overview}.
 
 \begin{figure}[ht]
 	\centering
@@ -240,87 +225,108 @@ la figure \ref{fig:quicksort-overview}
 	\label{fig:quicksort-overview}
 \end{figure}
 
-L'algorithme de partionnement doit réarranger le tableau pour que
-les 3 conditions suivantes soient vérifiées :
+The partitioning algorithm has to rearrange the array such that the following
+three conditions are met:
 
 \begin{itemize}
-	\item L'entrée \lstinline{a[j]} est à sa position finale pour
-	un certain $j$ ;
-	\item Les entrées \lstinline{a[lo..j-1]} sont inférieures ou
-	égales à \lstinline{a[j]} ;
-	\item Les entrées \lstinline{a[j+1..hi]} sont supérieures ou
-	égales à \lstinline{a[j]}.
+	\item The element \lstinline{a[j]} is in its final position for a certain
+	value of $j$. This element is called the pivot;
+	\item All elements coming before the pivot (\lstinline{a[lo..j-1]}) have
+	values less than or equal to the pivot;
+	\item All elements coming after the pivot (\lstinline{a[j+1..hi]}) have
+	values greater than or equal to the pivot.
 \end{itemize}
 
-Ces 3 conditions sont résumées sur la figure \ref{fig:part-overview}.
+These 3 conditions are summarised in \figuref{part-overview}.
 
 \begin{figure}[ht]
 	\centering
 	\includegraphics[scale=0.7]{img/partitioning-overview.png}
-	\caption{Partioning overview.}
+	\caption{Partitioning overview.}
 	\label{fig:part-overview}
 \end{figure}
 
-\subsubsection{Implémentation}
-La trace du code suivant se trouve à la figure \ref{fig:part-trace}
+\subsubsection{Implementation}
+The trace of the following code is found in \figuref{part-trace}
 
 \lstinputlisting{code/Quick.java}
 
 \begin{figure}[ht]
 	\centering
 	\includegraphics[scale=0.5]{img/partitioning.png}
-	\caption{Partioning trace.}
+	\caption{Partitioning trace.}
 	\label{fig:part-trace}
 \end{figure}
 
-\subsubsection{Complexité}
-Dans le pire cas, le tri rapide a une complexité quadratique.
-Il est possible d'éviter ce pire cas en mélangeant aléatoirement
-le tableau avant de le trier (cela fait du tri rapide un
-algorithme \textit{randomisé}).
+\subsubsection{Complexity}
+In the worst case, quicksort has $\bigoh(n^2)$ time complexity. This worst case
+scenario can be avoided by randomly ordering the array before sorting it (this
+makes quicksort a \emph{randomised} algorithm).
 
-Dans le cas moyen, le tri rapide a une complexité en $\mathcal{O}(n\log(n))$.
+In the average case, quicksort uses $\bigoh(n\log(n))$ time.
 
-\subsection{3-way quick sort}
-\subsubsection{Principes}
-Si le tableau à trier contient beaucoup d'éléments dupliqués (voir \textit{Dutch
-National Flag problem}), il est possible d'atteindre une complexité
-linéaire en modifiant un peu le tri rapide.
+\subsection{3-way quicksort}
+\subsubsection{Principles}
+If the array contains a lot of duplicate elements (for example the \emph{Dutch
+National Flag problem}), it is possible to obtain linear time complexity by
+modifying the quicksort algorithm slightly.
 
-L'idée est d'utiliser 3 partitions plutôt que 2, comme indiqué sur
-la figure \ref{fig:part3-overview}.
+This can be achieved by using 3 partitions instead of 2, as shown in
+\figuref{part3-overview}.
 
 \begin{figure}[ht]
 	\centering
 	\includegraphics[scale=0.7]{img/partitioning3-overview.png}
-	\caption{3-way partioning overview.}
+	\caption{3-way partitioning overview.}
 	\label{fig:part3-overview}
 \end{figure}
 
-Pour cela, une solution est d'effectuer un simple scan de la gauche
-vers la droite dans le tableau en maintenant une variable \lstinline{lt}
-tel que \lstinline{a[lo..lt-1]} sont inférieurs à $v$, une variable
-\lstinline{gt} tel quel \lstinline{a[gt+1..hi]} sont plus grands que $v$,
-une variable $i$ tel que \lstinline{a[lt..i-1]} sont égals à $v$ et
-\lstinline{a[i..gt]} n'ont pas encore été examinés.
+In order to do this, one must simply scan the array from left to right, while
+continuously updating a variable \lstinline{lt} such that
+\lstinline{a[lo..lt-1]} are less than $v$, a variable \lstinline{gt} such that
+\lstinline{a[gt+1..hi]} are greater than $v$, a variable $i$ such that
+\lstinline{a[lt..i-1]} are equal to $v$ and \lstinline{a[i..gt]} have not been
+checked yet.
 
-% TODO : add summary of complexity for sorting algorithms
-
-\subsubsection{Implémentation}
-La trace du code suivant se trouve à la figure \ref{fig:part3-trace}
+\subsubsection{Implementation}
+The trace of the following code is found in \figuref{part3-trace}
 
 \lstinputlisting{code/Quick3way.java}
 
 \begin{figure}[ht]
 	\centering
 	\includegraphics[scale=0.7]{img/partitioning3.png}
-	\caption{3-way partioning trace.}
+	\caption{3-way partitioning trace.}
 	\label{fig:part3-trace}
 \end{figure}
 
+\begin{table}
+\centering
+\begin{tabular}{c|c|c|c|c}
+	\hline
+	\multirow{2}{*}{Algorithm} & \multicolumn{3}{c|}{Time complexity} & Space
+	complexity\\
+	\cline{2-5}
+	 & Best & Average & Worst & Worst\\
+	 \hline
+	 Quicksort & $\bigomega(n \log n)$ & $\bigtheta(n \log n)$ & $\bigoh(n^2)$
+	 & $\bigoh(n \log n)$\\
+	 Merge sort & $\bigomega(n \log n)$ & $\bigtheta(n \log n)$ & $\bigoh(n
+	 \log n)$ & $\bigoh(n)$\\
+	 Insertion sort & $\bigomega(n)$ & $\bigtheta(n^2)$ & $\bigoh(n^2)$ &
+	 $\bigoh(1)$\\
+	 Selection sort & $\bigomega(n^2)$ & $\bigtheta(n^2)$ & $\bigoh(n^2)$ &
+	 $\bigoh(1)$\\
+	 Shellsort & $\bigomega(n \log n)$ & $\bigtheta(n (\log n)^2)$ & $\bigoh(n
+	 (\log n)^2)$ & $\bigoh(1)$\\
+	 \hline
+\end{tabular}
+\caption{Summary of complexities for sorting algorithms.}
+\end{table}
+
 \section{Searching}
 \subsection{Symbol tables}
-\begin{mydef}
+\begin{mydef}[Symbol table]
 A \textit{symbol table} is a data structure for key-value pairs that
 supports two operations: \textit{insert} (put) a new pair into the
 table and \textit{search} for (get) the value associated with a given
@@ -331,7 +337,7 @@ Here we adopt the \textit{associative array abstraction}, where you can
 think of a symbol table as being just like an array where keys are
 indices and values are array entries.
 
-The API for a generic basic symbol table is given in figure \ref{fig:st-api}.
+The API for a generic basic symbol table is given in \figuref{st-api}.
 
 \begin{figure}[ht]
 	\centering
@@ -343,7 +349,7 @@ The API for a generic basic symbol table is given in figure \ref{fig:st-api}.
 For applications where keys are \lstinline{Comparable}, we usually talk about
 \textit{ordered symbol tables}, where keys are kept in order.
 
-The API for a generic ordered symbol table is given in figure \ref{fig:ost-api}.
+The API for a generic ordered symbol table is given in \figuref{ost-api}.
 
 \begin{figure}[ht]
 	\centering
@@ -358,104 +364,58 @@ symbol table is a linked list of nodes that contain keys and values.
 
 Implementations of both \lstinline{get()} and \lstinline{put()} consist
 of scanning through the list. Hence, it is easy to show that the worst
-case is $\mathcal{O}(n)$ for both. In conclusion, a linked-list
+case complexity is $\bigoh(n)$ for both. In conclusion, a linked list
 implementation with sequential search is too slow to be used to solve
 huge problems.
 
 \subsubsection{Binary search in an ordered array}
-\begin{lstlisting}
-public class BinarySearchST<Key extends Comparable<Key>, Value>
-{
-\end{lstlisting}
+
+\lstinputlisting{code/BinarySearchSTClass.java}
 
 Now, we consider a full implementation of our ordered symbol-table API.
 The underlying data structure is a pair of parallel arrays, one for the
 keys and one for the values.
 
-\begin{lstlisting}
-    public BinarySearchST(int capacity) { 
-        keys = (Key[]) new Comparable[capacity]; 
-        vals = (Value[]) new Object[capacity]; 
-    }
-    
-    public int size() {
-        return N;
-    }
-\end{lstlisting}
+\lstinputlisting{code/BinarySearchST.java}
 
 The heart of the implementation is the \lstinline{rank()} method, which
 returns the number of keys smaller than a given key. For \lstinline{get()},
-the rank tells us precisely where the key is to be found it is in the table.
+the rank tells us precisely where the key is to be found if it is in the table.
 
-\begin{lstlisting}
-	public Value get(Key key) {
-		if (isEmpty()) return null;
-		int i = rank(key); 
-		if (i < N && keys[i].compareTo(key) == 0) return vals[i];
-    		return null;
-	} 
-\end{lstlisting}
+\lstinputlisting{code/Get.java}
 
 For \lstinline{put()}, the rank tells us precisely where to update the value
 when the key is in the table, and precisely where to put the key when the
-key is not in the table. We move all larger keys one position to make room
-and insert the given key and value into the proper positions in their
+key is not in the table. We move all larger keys one position to the right to
+make room and insert the given key and value into the proper positions in their
 respective arrays.
 
-\begin{lstlisting}
-	public void put(Key key, Value val)  {
-		int i = rank(key);
-
-		if (i < N && keys[i].compareTo(key) == 0) {
-			vals[i] = val; return;
-		}
-
-		for (int j = N; j > i; j--)  {
-			keys[j] = keys[j-1]; vals[j] = vals[j-1];
-		}
-        
-		keys[i] = key; vals[i] = val;
-		N++;
-	} 
-\end{lstlisting}
+\lstinputlisting{code/Put.java}
 
 To find the rank of a given key, we take advantage of the fact that keys
 in the array are ordered and use \textit{binary search}. An iterative
 implementation of the \lstinline{rank()} method is given below.
 
-\begin{lstlisting}
-	public int rank(Key key) {
-		int lo = 0, hi = N-1;
-		while(lo <= hi) {
-			int mid = low + (hi - lo)/2;
-			int cmp = key.compareTo(keys[mid]);
-			if		(cmp < 0) hi = mid-1;
-			else if 	(cmp > 0) lo = mid+1;
-			else	 return mid; 		
-		}
-		
-		return lo;	
-	}
-\end{lstlisting}
+\lstinputlisting{code/Rank.java}
 
 Here, it is easy to show that the complexity of binary search
-is $\mathcal{O}(n\log(n))$. Unfortunately, insertion is still
-to slow : $\mathcal{O}(n)$.
+is $\bigoh(n \log n)$. Unfortunately, insertion is still
+too slow: $\bigoh(n)$.
 
 \subsection{Binary search tree}
 \label{sec:tree}
-Here we'll combine the flexibility of insertion in a linked-list
-with the efficiency of search in an ordered array.
+Here we'll combine the flexibility of insertion in a linked list
+with the efficiency of \emph{search} in an ordered array.
 
-\begin{mydef}
+\begin{mydef}[Binary Search Tree (BST)]
 A \textit{binary search tree} (BST) is a binary tree where each node
-has a \lstinline{Comparable} key (and a associated value) and
+has a \lstinline{Comparable} key (and an associated value) and
 satisfies the restriction that the key in any node is larger than
-the keys in all nodes in that nodes' left subtree and smaller
+the keys in all nodes in that node's left subtree and smaller
 than the keys in all nodes in that node's right subtree.
 \end{mydef}
 
-This restriction is illustrated in figure \ref{fig:bst-anatomy}.
+This restriction is illustrated in \figuref{bst-anatomy}.
 Note that on a binary tree that is not a binary \textit{search}
 tree, we don't have this restriction.
 
@@ -472,85 +432,33 @@ represent the same set.
 \end{myrem}
 
 \subsubsection{Basic implementation}
-\begin{lstlisting}
-public class BST<Key extends Comparable<Key>, Value>
-{
-	private Node root;
-\end{lstlisting}
+\lstinputlisting{code/BSTClass.java}
 
 Just as we did for linked lists, we define a private nested class
 to define nodes in BSTs.
 
-\begin{lstlisting}
-	public class Node {
-		private Key key;
-		private Value val;
-		private Node left, right;
-		private int N;
-		
-		public Node(Key key, Value val, int N) {
-			this.key = key; this.val = val; this.N = N;		
-		}	
-	}
-\end{lstlisting}
+\lstinputlisting{code/NodeClass.java}
 
 Each node contains a key, a value, a left and right link and a node
 count. This last field facilitates the implementation of various
-ordered symbol-table operations.
+ordered symbol table operations.
 
-\begin{lstlisting}
-	public int size() {
-		return size(root);	
-	}
-	
-	private int size(Node x) {
-		if (x == null) return 0;
-		else return x.N;	
-	}
-\end{lstlisting}
+\lstinputlisting{code/Size.java}
 
 Thanks to the recursive definition of a tree, we can implement
-the \lstinline{get()} easily in a recursive way.
+the \lstinline{get()} method easily in a recursive way.
 
-\begin{lstlisting}
-	public Value get(Key key) {
-		return get(root, key);	
-	}
-	
-	private Value get(Node x, Key key) {
-		if (x == null) return null;
-		
-		int cmp = key.compareTo(x.key);
-		if      (cmp > 0) return get(x.right, key);
-		else if (cmp < 0) return get(x.left, key);
-		else	 return x.val;
-	}
-\end{lstlisting} 
+\lstinputlisting{code/NodeGet.java}
 
 The same holds for the \lstinline{put()} method.
 
-\begin{lstlisting}
-	public void put(Key key, Value val) {
-		root = put(root, key, val);	
-	}
-	
-	private Node put(Node x, Key key, Value val) {
-		if (x == null) return new Node(key, val, 1);
-		
-		int cmp = key.compareTo(x.key);
-		if      (cmp > 0) x.right = put(x.right, key, val);
-		else if (cmp < 0) x.left = put(x.left, key, val);
-		else x.val = val;
-		x.N = size(x.left) + size(x.right) + 1;
-		return x;
-	}
-\end{lstlisting}
+\lstinputlisting{code/NodePut.java}
 
 To get a better understanding of the dynamics of these
 recursive implementations, you can think of the code
 \textit{before} the recursive calls as happening on the
 way \textit{down} the tree. Then, think of the code \textit{after}
-the recursive calls as happeing on the way \textit{up} the tree.
+the recursive calls as happening on the way \textit{up} the tree.
 
 Now, let's look at how to delete a node in a BST. This is the most
 difficult operation to implement. We choose here to use the
@@ -558,55 +466,31 @@ difficult operation to implement. We choose here to use the
 $x$ by replacing it with its \textit{successor}. If $x$ has
 a right child, its successor is the node with the smallest
 key in its right subtree. This task is accomplished
-in 4 steps :
+in 4 steps:
 
 \begin{itemize}
-	\item Save a link to the node to be deleted in \lstinline{t} ;
-	\item Set \lstinline{x} to point to its successor
-	\lstinline{min(t.right)} ;
-	\item Set the right link of \lstinline{x} to
-	\lstinline{deleteMin(t.right)} ;
-	\item Set the left link of \lstinline{x} to \lstinline{t.left}.
+	\item save a link to the node to be deleted in \lstinline{t};
+	\item set \lstinline{x} to point to its successor
+	\lstinline{min(t.right)};
+	\item set the right link of \lstinline{x} to
+	\lstinline{deleteMin(t.right)};
+	\item set the left link of \lstinline{x} to \lstinline{t.left}.
 \end{itemize}
 
-\begin{lstlisting}
-	public void delete(Key key) {
-		root = delete(root, key);	
-	}
-	
-	private Node delete(Node x, Key key) {
-		if (x == null) return null;
-		int cmp = key.compareTo(x.key);
-		if      (cmp < 0) x.left = delete(x.left, key);
-		else if (cmp > 0) x.right = delete(x.right, key);
-		else {
-			if(x.right == null) return x.left;
-			if(x.left == null) return x.right;
-			/* Choose successor to replace x (Hibbard)
-			if the node to delete has two children */
-			Node t = x;
-			x = min(t.right);
-			x.right = deleteMin(t.right);
-			x.left = t.left;		
-		}	
-		
-		x.N = size(x.left) + size(x.right) +1;
-		return x;
-	}
-\end{lstlisting}
+\lstinputlisting{code/HibbardDeletion.java}
 
 Even though this method does the job, it has a flaw that might
-cause performance problems in some practical situations. The problem
+cause performance issues in some practical situations. The problem
 is that the choice of using the successor is arbitrary and not
 symmetric. This will cause the BST to become skewed toward the
 left on the long term for random deletions and insertions
-\footnote{See the last video on 
+\footnote{See the last video on
 \url{http://algs4.cs.princeton.edu/32bst/}.}.
 
 \begin{myrem}
 Note that deletion in a BST is not commutative. Try for
 example to delete 4 and then 3 and 3 and then 4 in
-the tree given in figure \ref{fig:nc-deletion}.
+the tree given in \figuref{nc-deletion}.
 
 \begin{figure}[ht]
 	\centering
@@ -623,54 +507,45 @@ the tree given in figure \ref{fig:nc-deletion}.
 \end{myrem}
 
 \begin{myrem}
-Others methods from the API are in the book.
+Other methods from the API are in the book.
 \end{myrem}
 
 \subsubsection{Analysis}
 The running times of algorithms on binary search trees depend
 on the shapes of the trees, which in turn, depend on the
 order in which keys are inserted. In the best case, a tree
-with $N$ nodes could be perfectly balanced, with $\log(n)$
-nodes between the root and each null links (we call this the
+with $N$ nodes could be perfectly balanced, with $\lg N$
+nodes between the root and each null link (we call this the
 \textit{depth} of a tree). In the worst case
 there could be $N$ nodes on the search patch.
 
-% Better to say "proposition" than "property" ? Do I need to change
-% eplcommon.sty to add this?
-\begin{myprop}
-Search hits in BST build from $N$ random keys requires $\sim 2\log N$
-(about $1.39\log(n)$) compares, on the average.
-\end{myprop}
+\begin{mypropo}
+Search hits in a BST built from $N$ random keys requires $\sim 2\ln N$
+(about $1.39 \lg N$) compares on the average.
+\end{mypropo}
 
-\begin{myprop}
-Insertions and search misses in a BST build from $N$ random
-keys require $\sim 2\log N$ (about $1.39\log(n)$) compares on the
+\begin{mypropo}
+Insertion and search misses in a BST built from $N$ random
+keys require $\sim 2\ln N$ (about $1.39 \lg N$) compares on the
 average.
-\end{myprop}
+\end{mypropo}
 
-\begin{myprop}
-In a BST, all operations take time proportional to the height of
-the tree in the worst case.
-\end{myprop}
+\begin{mypropo}
+Search, insertion, finding the maximum, floor, ceiling, rank, select, delete
+the minimum, delete the maximum, delete, and range count operations all take
+time proportional to the height of the tree, in the worst case.
+\end{mypropo}
 
 \subsubsection{Binary tree traversal methods}
-We will use the BST given in figure \ref{fig:bst-anatomy}
+We will use the BST given in \figuref{bst-anatomy}
 for the following examples and assume that the method
-\lstinline$void visit(Node h)$ print the key of node
+\lstinline$void visit(Node h)$ prints the key of node
 \lstinline$h$.
 
 \paragraph{Preorder (\textit{préfixe)}}
 Visit a node, then its left child and right child.
-\begin{lstlisting}
-public static void preOrder(Node h) {
-	if(t != null) {
-		visit(t);
-		preOrder(t.left);
-		preOrder(t.right);	
-	}
-}
-\end{lstlisting}
-Applied on figure \ref{fig:bst-anatomy} :
+\lstinputlisting{code/Preorder.java}
+Applied on \figuref{bst-anatomy} :
 S E A C R H X.
 
 \paragraph{Inorder (\textit{infixe})}
@@ -678,102 +553,86 @@ This method is equivalent to projecting the keys
 of the tree on a line at the bottom of the tree :
 \textbf{keys appear in sorted order}.
 
-\begin{lstlisting}
-public static void inOrder(Node h) {
-	if(t != null) {
-		inOrder(t.left);
-		visit(t);
-		inOrder(t.right);	
-	}
-}
-\end{lstlisting}
-Applied on figure \ref{fig:bst-anatomy} :
+\lstinputlisting{code/Inorder.java}
+Applied on \figuref{bst-anatomy} :
 A C E H R S X.
 
-\paragraph{Postorder (\textit{postfixe} ou \textit{suffice})}
-Visit each node after having visited each children.
-\begin{lstlisting}
-public static void postOrder(Node h) {
-	if(t != null) {
-		postOrder(t.left);
-		postOrder(t.right);
-		visit(t);
-	}
-}
-\end{lstlisting}
-Applied on figure \ref{fig:bst-anatomy} :
+\paragraph{Postorder (\textit{postfixe} ou \textit{suffixe})}
+Visit each node after having visited each child.
+\lstinputlisting{code/Postorder.java}
+Applied on \figuref{bst-anatomy} :
 C A R H E X S.
 
 \subsection{Balanced search tree}
-The algorithms in the previous subsection have poor worst-case,
+The algorithms in the previous subsection have poor worst case
 performance. Here we introduce a type of binary search tree where
 costs are \textit{guaranteed} to be logarithmic. Ideally, we would
 like to keep our binary search tree perfectly balanced, i.e. in an
-$N$-node tree, we would like the height to be $\log(N)$. Unfortunately,
+$N$-node tree, we would like the height to be $\lg N$. Unfortunately,
 maintaining this property is too expensive. Hence we will consider
 a data structure that slightly relaxes the perfect balance
 requirement to provide guaranteed logarithmic performance.
 
-\begin{mydef}[2-3 search trees]
+\begin{mydef}[2-3 search tree]
 A \textit{2-3 search tree} is a tree that is either empty or
 \begin{itemize}
-	\item A \textit{2-node}, with one key (and associated value)
-	and two links, a left link to 2-3 search tree with smaller
-	keys, and a right link to a 2-3 search tree with larger keys ;
-	\item A \textit{3-node}, with two keys (and associated values)
-	and \textit{three} links, a left link to 2-3 search tree with
+	\item a \textit{2-node}, with one key (and associated value)
+	and two links, a left link to a 2-3 search tree with smaller
+	keys, and a right link to a 2-3 search tree with larger keys;
+	\item a \textit{3-node}, with two keys (and associated values)
+	and \textit{three} links, a left link to a 2-3 search tree with
 	smaller keys, a middle link to a 2-3 search tree with keys
-	between the node's key, and a right link to a 2-3 search tree
+	between the node's keys, and a right link to a 2-3 search tree
 	with larger keys.
 \end{itemize}
 As usual, we refer to a link to an empty tree as a \textit{null link}.
 \end{mydef}
 
-\begin{myprop}
+\begin{myprop}[Perfectly balanced 2-3 search tree]
 A \textit{perfectly balanced} 2-3 search tree is one whose null
 links are all the same distance from the root.
 \end{myprop}
 
 Searching in a 2-3 search tree is almost the same as searching
 in a BST. The only difference occurs when we encounter a 3-node,
-instead of just looking if the target key is smaller or lager
+instead of just looking if the target key is smaller or larger
 than the keys, we also have to check if the target key is
 between the two keys of the 3-node.
 
 Inserting in a 2-3 search tree is more complicated. The primary reason
 that 2-3 trees are useful is that we can do insertions and still
 maintain perfect balance. To achieve this, we have to take into
-account different cases illustrated below 
-(see figure \ref{fig:23tree-inserta}, \ref{fig:23tree-insertb}
-and \ref{fig:23tree-insertc}).
+account different cases illustrated below
+(see \figuref{23tree-inserta}, \figuref{23tree-insertb}
+and \figuref{23tree-insertc}).
 
-\begin{myprop}
+\begin{mypropo}
 Transformations caused by the 2-3 tree insertion algorithms
 are purely \textit{local}: no part of the tree needs to be examined
 or modified other than the specified nodes and links. Moreover, these
 local transformations preserve the global properties that the tree
 is ordered and perfectly balanced.
-\end{myprop}
+\end{mypropo}
 
-\begin{myprop}
+\begin{mypropo}
 Search and insert operations in a 2-3 tree with $N$ keys are
-guaranteed to visit at most $\log N$ nodes. Indeed, the height
+guaranteed to visit at most $\lg N$ nodes. Indeed, the height
 of an $N$-node 2-3 tree is between $\log_3 N$ (if the tree is
-all 3-nodes) and $\log N$ (if the tree is all 2-nodes).
-\end{myprop}
+all 3-nodes) and $\lg N$ (if the tree is all 2-nodes).
+\end{mypropo}
 
 \begin{figure}[ht]
 	\centering
-	\begin{subfigure}{.5\textwidth}
+	\begin{subfigure}[t]{.5\textwidth}
 		\centering
   		\includegraphics[width=.7\linewidth]{img/23tree-insert2.png}
  		\caption{Inserting into a 2-node.}
   		\label{fig:23tree-insert2}
 	\end{subfigure}%
-	\begin{subfigure}{.5\textwidth}
+	\begin{subfigure}[t]{.5\textwidth}
   		\centering
   		\includegraphics[width=0.5\linewidth]{img/23tree-insert3a.png}
-  		\caption{Inserting into a single 3-node}
+  		\caption{Inserting into a single 3-node.}
   		\label{fig:23tree-insert3a}
 	\end{subfigure}
 	\caption{}
@@ -789,13 +648,13 @@ all 3-nodes) and $\log N$ (if the tree is all 2-nodes).
 
 \begin{figure}[ht]
 	\centering
-	\begin{subfigure}{.5\textwidth}
+	\begin{subfigure}[t]{.5\textwidth}
 		\centering
   		\includegraphics[width=.7\linewidth]{img/23tree-insert3c.png}
  		\caption{Insert intro a 3-node whose parent is a 3-node.}
   		\label{fig:23tree-insert3c}
 	\end{subfigure}%
-	\begin{subfigure}{.5\textwidth}
+	\begin{subfigure}[t]{.5\textwidth}
   		\centering
   		\includegraphics[width=0.6\linewidth]{img/23tree-split.png}
   		\caption{Splitting the root.}
@@ -808,13 +667,13 @@ all 3-nodes) and $\log N$ (if the tree is all 2-nodes).
 \subsubsection{Implementation}
 To implement a 2-3 tree, we consider a simple representation
 known as \textit{red-black BST}. The basic idea behind red-black
-BSTs is to encode 2-3 tree by starting with standard BSTs and adding
+BSTs is to encode 2-3 trees by starting with standard BSTs and adding
 extra information to encode 3-nodes. We think of the links as being of
-two different type: \textit{red} links, which bind together two 2-nodes
-to represent a 3-nodes, and \textit{black} links, which bind together
+two different types: \textit{red} links, which bind together two 2-nodes
+to represent a 3-node, and \textit{black} links, which bind together
 the 2-3 tree. Specifically, we represent 3-nodes as two 2-nodes connected
-by a single red link that leans left. This is illustrated in figure
-\ref{fig:redblack-encoding}.
+by a single red link that leans left. This is illustrated in
+\figuref{redblack-encoding}.
 
 One advantage of using such a representation is that it allows us
 to use our \lstinline$get()$ code for standard BST search without
@@ -822,32 +681,34 @@ modification.
 
 \begin{mydef}[Equivalent definition]
 A red-black BST is a BST having red and black links and satisfying
-the following three restrictions :
+the following three restrictions:
 \begin{itemize}
-	\item Red links lean left ;
-	\item No node has two red links connected to it ;
-	\item The tree has \textit{perfect black balance}: every path from
+	\item red links lean left;
+	\item no node has two red links connected to it;
+	\item the tree has \textit{perfect black balance}: every path from
 	the root to a null link has the same number of black links - we refer
 	to this number as the tree's \textit{black height}.
 \end{itemize}
 \end{mydef}
 
-\begin{myprop}
+\begin{mypropo}
+\label{correspondence}
 There is a 1-1 correspondence between red-black BSTs and 2-3 trees.
-\end{myprop}
+\end{mypropo}
 
-This last property is illustrated in figure \ref{fig:redblack-1-1}.
+Proposition \ref{correspondence} is illustrated in \figuref{redblack-1-1}.
 
 \begin{figure}[ht]
 	\centering
-	\begin{subfigure}{.5\textwidth}
+	\begin{subfigure}[t]{.48\textwidth}
 		\centering
 		\includegraphics[scale=0.5]{img/redblack-encoding.png}
 		\caption{Encoding a 3-node with two 2-nodes connected by
 		a left leaning red link.}
 		\label{fig:redblack-encoding}
 	\end{subfigure}%
-	\begin{subfigure}{.5\textwidth}
+	\hfill
+	\begin{subfigure}[t]{.48\textwidth}
 		\centering
 		\includegraphics[scale=0.5]{img/redblack-1-1.png}
 		\caption{1-1 correspondence between red-black BSTs and 2-3 trees.}
@@ -857,53 +718,29 @@ This last property is illustrated in figure \ref{fig:redblack-1-1}.
 	\label{fig:redblack-principles}
 \end{figure}
 
-\begin{lstlisting}
-public class RedBlackBST<Key extends Comparable<Key>, Value>
-{
-	private Node root;
-\end{lstlisting}
+\lstinputlisting{code/RedBlackBST.java}
 
 As usual, we define a private nested class to define a node.
 
-\begin{lstlisting}
-	private static final boolean RED = true;
-	private static final boolean BLACK = false;
-	
-	private Class Node {
-		Key key; Value val;
-		Node left, right;
-		int N;
-		boolean color;	
-	
-		Node(Key key, Value val, int N, boolean color) {
-			this.key = key; this.val = val;
-			this.N = N; this.color = color;		
-		}	
-	}
-	
-	private boolean isRed(Node x) {
-		if(x == null) return false;
-		return x.color == RED;	
-	}
-\end{lstlisting}
+\lstinputlisting{code/RedBlackNode.java}
 
 When we refer to the color of a node, we are referring
 to the color of the link pointing to it. By convention, null
 links are black. Now we consider two methods
 \lstinline$Node rotateLeft(Node h)$ and \lstinline$Node rotateRight(Node h)$.
 These two methods will help us to write other methods later. They
-are illustrated in figure \ref{fig:redblack-left-rotate} and
-\ref{fig:redblack-right-rotate}.
+are illustrated in \figuref{redblack-left-rotate} and
+\figuref{redblack-right-rotate}.
 
 \begin{figure}[ht]
 	\centering
-	\begin{subfigure}{.5\textwidth}
+	\begin{subfigure}[t]{.5\textwidth}
 		\centering
 		\includegraphics[scale=0.5]{img/redblack-left-rotate.png}
 		\caption{Left rotate.}
 		\label{fig:redblack-left-rotate}
 	\end{subfigure}%
-	\begin{subfigure}{.5\textwidth}
+	\begin{subfigure}[t]{.5\textwidth}
 		\centering
 		\includegraphics[scale=0.5]{img/redblack-right-rotate.png}
 		\caption{Right rotate.}
@@ -913,38 +750,14 @@ are illustrated in figure \ref{fig:redblack-left-rotate} and
 	\label{fig:redblack-rotations}
 \end{figure}
 
-\begin{lstlisting}
-	private Node rotateLeft(Node h) {
-		Node x = h.right;
-		h.right = x.left; x.left = h;
-		x.color = h.color; h.color = RED;
-		x.N = h.N;
-		h.N = 1 + size(h.left) + size(h.right);
-		return x;
-	}
-	
-	private Node rotateRight(Node h) {
-		Node x = h.left;
-		h.left = x.right; x.right = h;
-		x.color = h.color; h.color = RED;
-		x.N = h.N;
-		h.N = 1 + size(h.left) + size(h.right);
-		return x;
-	}
-\end{lstlisting}
+\lstinputlisting{code/NodeRotate.java}
 
 Next we consider a simple method which allows us to
 split a 4-node.
 
-\begin{lstlisting}
-	private void flipColors(Node h) {
-		h.color = RED;
-		h.left.color = BLACK;
-		h.right.color = BLACK;	
-	}
-\end{lstlisting}
+\lstinputlisting{code/FlipColors.java}
 
-This method is illustrated in figure \ref{fig:color-flip}.
+This method is illustrated in \figuref{color-flip}.
 
 \begin{figure}[ht]
 	\centering
@@ -956,29 +769,7 @@ This method is illustrated in figure \ref{fig:color-flip}.
 With the last three methods, we have everything we need to
 implement insertion in red-black BSTs.
 
-\begin{lstlisting}
-	public void put(Key key, Value val) {
-		root = put(root, key, val);
-		root.color = BLACK;	
-	}
-	
-	private Node put(Node h, Key key, Value val) {
-		// Do standard insert, with red link to parent.
-		if(h == null) return new Node(key, val, 1, RED);
-		
-		int cmp = key.compareTo(h.key);
-		if      (cmp > 0) h.right = put(h.right, key, val);
-		else if (cmp < 0) h.left = put(h.left, key, val);
-		else h.val = val;
-		
-		if (isRed(h.left)  && isRed(h.left.left)) h = rotateRight(h);
-		if (!isRed(h.left) && isRed(h.right))     h = rotateLeft(h);
-		if (isRed(h.left)  && isRed(h.right))     flipColors(h);
-		
-		h.N = 1 + size(h.left) + size(h.right);
-		return h:
-	}	
-\end{lstlisting}
+\lstinputlisting{code/RedBlackPut.java}
 
 A summary of rotations and colors flipping involved in insert is
 given in figure \ref{fig:insert-summary}.
@@ -990,52 +781,52 @@ given in figure \ref{fig:insert-summary}.
 	\label{fig:insert-summary}
 \end{figure}
 
-% TODO : deletion in a red-bl	ack BST
+% TODO : deletion in a red-black BST
 
 \subsubsection{Analysis}
-\begin{myprop}
-The height\footnote{Here we are not talking about black height!} 
+\begin{mypropo}
+The height\footnote{Here we are not talking about black height!}
 of a red-black BST with $N$ nodes
-is no more than $2\log N$. Indeed, the worst case
+is no more than $2\lg N$. Indeed, the worst case
 is a 2-3 tree that is all 2-nodes except that the leftmost
 is made up of 3-nodes. The path taking left links from the
-root is twice as long as the path of length $\sim \log N$
+root is twice as long as the path of length $\sim \lg N$
 that involves just 2-nodes.
-\end{myprop}
+\end{mypropo}
 
-The worst case of the last property corresponds to the first
-tree of figure \ref{fig:redblack-1-1} with $S$ removed.
+The worst case of the last proposition corresponds to the first
+tree of \figuref{redblack-1-1} with $S$ removed.
 
 \begin{myprop}
 The average length of a path from the root to a node
-in a red-black BST with $N$ nodes is $\sim 1.00\log N$.
+in a red-black BST with $N$ nodes is $\sim 1.00\lg N$.
 \end{myprop}
 
-\begin{myprop}
+\begin{mypropo}
 In a red-black BST, the following operations take logarithmic time
 in the worst case: search, insertion, finding the minimum/maximum,
 floor, ceiling, rank, select, delete the minimum/maximum, delete
 and range count.
-\end{myprop}
+\end{mypropo}
 
 \subsection{Hash tables}
 
 If keys are small integers, we can use an array to implement
 an unordered symbol table, by interpreting the key as an array
 index so that we can store the value associated with the key
-\lstinline$i$ in array entry \lstinline$i$, ready for
-\textbf{immediate access}. Thanks to \textit{hashing}, we can
+\lstinline$i$ in array position \lstinline$i$, ready for
+\textbf{immediate access}. Thanks to \emph{hashing}, we can
 transform any type of key to array indexes. Ideally, different
 keys would map to different indices. However, this ideal
 is generally beyond our reach, so we have to face the possibility
-that two or more different keys may hash to the same array index :
+that two or more different keys may hash to the same array index:
 we need a \textit{collision resolution} process. We'll consider
-two different approaches to collision resolution : \textit{separate
+two different approaches to collision resolution: \textit{separate
 chaining} and \textit{linear probing}.
 
 \subsubsection{Hash functions}
 
-\begin{wrapfigure}{R}{0.3\textwidth}
+\begin{wrapfigure}{r}{0.3\textwidth}
   \begin{center}
     \includegraphics[width=0.15\textwidth]{img/modular-hashing.png}
   \end{center}
@@ -1045,50 +836,46 @@ chaining} and \textit{linear probing}.
 
 If we have an array that can hold $M$ key-value pairs, then we
 need a hash function that can transform any given key into an
-integer in the range $[0, M-1]$. We seek a hash function that both
-is \textbf{efficient to compute} and \textbf{uniformly distributes}
+integer in the range $\intervalcc{0}{M-1}$. We seek a hash function that is both
+\textbf{efficient to compute} and \textbf{uniformly distributes}
 the keys.
 
 \paragraph{Hashing positive integers}
 The most commonly used method for hashing integers is called
 \textit{modular hashing}: we choose the array size $M$ to be prime
 and, for any positive integer key $k$, compute the remainder
-when dividing $k$ by $M$ : \lstinline$k % M$.
+when dividing $k$ by $M$ : $k \bmod M$.
 
 If $M$ is not prime, it may be the case that not all the bits
 of the key play a role, which amounts to missing an opportunity
 to disperse the values evenly. For example, if the keys are
 base 10 numbers and $M$ is $10^k$, then only the $k$ least
-significant digits are used (see figure \ref{fig:modular-hashing}).
+significant digits are used (see \figuref{modular-hashing}).
 
 \paragraph{Hashing floating-point numbers}
 One way to do this is to use modular hashing on the binary
-representation of the key (this is what Java does).
+representation of the key (this is what \java{} does).
 
 \paragraph{Hashing strings}
 Again, we can apply modular hashing on each character of
 the string :
 
-\begin{lstlisting}
-int hash = 0;
-for(int i = 0; i < s.length(); i++)
-	hash = (R * hash + s.charAt(i)) % M;
-\end{lstlisting}
+\lstinputlisting{code/Horner.java}
 
-This algorithm is called the \textit{Horner's method}.
-The use of a small primer integer such as 31 ensures
+This algorithm is called \textit{Horner's method}.
+The use of a small prime integer such as 31 ensures
 that the bits of all the characters play a role.
 
 \begin{myrem}
 \label{rem:mod-prop}
-Note that applying \lstinline|% M| at the end (i.e. outside
+Note that applying $\mod M$ at the end (i.e. outside
 the loop) gives the same result (it's a property of the
 modulus operation). But by doing so, we may encounter
 \lstinline|int| overflow for long strings.
 \end{myrem}
 
-\paragraph{Java conventions}
-In Java, every data type inherits a method called
+\paragraph{\java{} conventions}
+In \java, every data type inherits a method called
 \lstinline$hashCode()$ that returns a 32-bit integer.
 The implementation of \lstinline$hashCode()$ for a data
 type must be \textbf{consistent with equals}, if
@@ -1101,41 +888,37 @@ if \lstinline$hashCode()$ values are the same, we still
 have to use \lstinline$equals()$ to check whether or not
 objects are equal (as collisions may occur).
 
-\paragraph{Converting a hashcode to an array index}
+\paragraph{Converting a \lstinline$hashCode()$ to an array index}
 Since our goal is an array index, not a 32-bit integer, we
 combine \lstinline$hashCode()$ with modular hashing
 to produce integers between 0 and $M-1$ :
 
-\begin{lstlisting}
-private int hash(Key x) {
-	return (x.hashCode() & 0x7fffffff) % M);   //be careful! "&" means bit wise AND
-}
-\end{lstlisting}
+\lstinputlisting{code/Hash.java}
 
 This code also masks off the sign bit (to turn the
 32-bit number into a 31-bit non-negative integer).
 We usually use a prime number for the hash table
 size $M$ to attempt to make use of all the bits of
-the hash code.
+the \lstinline$hashCode()$.
 
 \paragraph{Software caching}
-If computing the hash code is expensive, it may be
+If computing the \lstinline$hashCode()$ is expensive, it may be
 worthwhile to \textit{cache the hash} for each key.
 That is, we maintain an instance variable \lstinline$hash$
 in the key type that contains the value of
-\lstinline$hashCode()$ for each key object. Java uses
+\lstinline$hashCode()$ for each key object. \java{} uses
 this technique for \lstinline$String$ objects.
 
 \subsubsection{Hashing with separate chaining}
 Now that we know how to hash, we need a collision resolution
 process. The first collision resolution process is illustrated
-in figure \ref{fig:separate-chaining}.
+in \figuref{separate-chaining}.
 
 \begin{figure}[ht]
 	\centering
 	\includegraphics[scale=0.6]{img/separate-chaining.png}
-	\caption{For each of the $M$ array indices, we build a 
-	linked list of the key-value pairs  whose key hash to that
+	\caption{For each of the $M$ array indices, we build a
+	linked list of the key-value pairs  whose key hashes to that
 	index. To search in those linked lists, we use sequential
 	search in an unordered linked list.}
 	\label{fig:separate-chaining}
@@ -1146,52 +929,22 @@ Implementation of separate chaining is very easy
 (\lstinline|SequentialSearchST| is the implementation
 of the sequential search in an unordered linked list).
 
-\begin{lstlisting}
-public class SeparateChainingHashST<Key, Value> 
-{
-	private int M;
-	private SequentialSearchST<Key, Value>[] st;
-	
-	public SeparateChainingHashST() {
-		this(997);   //default size to be 1000 faster than SequentialSearchST	
-	}
-	
-	public SeparateChainingHashST(int M) {
-		this.M = M;
-		st = (SequentialSearchST<Key, Value>[]) new SequentialSearchST[M];
-		for(int i = 0; i < M; i++) {
-			st[i] = new SequentialSearchST();		
-		}	
-	}
-	
-	private int hash(Key key) {
-		return (key.hashCode() & 0x7fffffff) % M;	
-	}
-	
-	public Value get(Key key) {
-		return (Value) st[hash(key)].get(key);	
-	}
-	
-	public void put(Key key, Value val) {
-		st[hash(key)].put(key, val);	
-	}
-}
-\end{lstlisting}
+\lstinputlisting{code/SeparateChaining.java}
 
 \paragraph{Analysis}
-\begin{myprop}
+\begin{mypropo}
 In a separate-chaining hash table with $M$ lists and $N$
 keys, the probability that the number of keys in a list
 is within a small constant factor of $N/M$ is extremely
-close ton 1.
-\end{myprop}
+close to 1.
+\end{mypropo}
 
-This last property makes the assumption that we use
+This last proposition makes the assumption that we use
 a uniform hashing function.
 
 \begin{myprop}
-As a consequence of the last property, the number of
-compares for search miss and insert is $\sim N/M$.
+As a consequence of the last proposition, the number of
+compares for \emph{search} and \emph{insert} is proportional to $N/M$.
 \end{myprop}
 
 \subsubsection{Hashing with linear probing}
@@ -1200,146 +953,72 @@ $N$ key-value pairs in a hash table of size $M > N$,
 relying on empty entries in the table to help with
 collision resolution. Such methods are called
 \textit{open-addressing} hashing methods. The simplest
-one is called linear probing : when there is a collision,
+one is called linear probing: when there is a collision,
 then we just check the next entry in the table.
 
 \paragraph{Implementation}
 As with separate chaining, implementation is quite
 straightforward.
 
-\begin{lstlisting}
-public class LinearProbingHashST<Key, Value>
-{
-	private int N; // number of key-value pairs in the table
-	private int M; // size of linear-probing table
-	private Key[] keys;
-	private Values[] vals;
-	
-	public LinearProbingHashST() {
-		this(4); // Initializes with an initial capacity of 4	
-	}	
-	
-	public LinearProbingHashST(int capacity) {
-		M = capacity;		
-		keys = (Key[]) new Object[M];
-		vals = (Value[]) new Object[M];	
-	}
-	
-	private int hash(Key key) {
-		return (key.hashCode() & 0x7fffffff) % M;	
-	}
-	
-	public void put(Key key, Value val) {
-		if(N >= M/2) resize(2*M);
-		
-		int i;
-		for(i = hash(key); keys[i] != null; i = (i + 1) % M) {
-			if(keys[i].equals(key)) {
-				vals[i] = val;
-				return;
-			}		
-		}	
-		
-		keys[i] = key;
-		vals[i] = val;
-		N++;
-	}
-	
-	public Value get(Key key) {
-		for(int i = hash(key); keys[i] != null; i = (i + 1) % M) {
-			if(keys[i].equals(key)) {
-				return vals[i];			
-			}
-		}
-		
-		return null;	
-	}
-	
-	public void delete(Key key) {
-		if(!contains(key)) return;
-		int i = hash(key);
-		while(!key.equals(keys[i]))
-			i = (i + 1) % M;
-		keys[i] = null;
-		vals[i] = null;
-		i = (i + 1) % M;
-		while(keys[i] != null) {
-			Key keyToRedo = keys[i];
-			Value valToRedo = vals[i];
-			keys[i] = null;
-			vals[i] = null;
-			N--;
-			put(keyToRedo, valToRedo);
-			i = (i + 1) % M;		
-		}
-		
-		N--;
-		if(N > 0 && N <= M/8)
-			resize(M/2);
-	}
-}
-\end{lstlisting}
+\lstinputlisting{code/LinearProbing.java}
 
-\begin{mydef}
+\begin{mydef}[Load factor]
 We define $\alpha = N/M$ as the \textit{load factor}
 of a hash table. For separate chaining, $\alpha$ is
 the average number of keys per list and is often
-larger than 1. For linear probing, $\alpha$ is the
-percentage of table entries that are occupied : it
-cannot be greater than 1\footnote{If the load
-factor reach 1, search miss would go into an
-infinite loop.}.
+larger than 1. For open addressing, $\alpha$ is the
+percentage of table entries that are occupied: it
+\emph{must} be less than 1.\footnote{If the load
+factor reaches 1, search misses would go into an
+infinite loop.}
 \end{mydef}
 
 The average cost of linear probing depends on \textit{clusters}
 (entries which clump together into contiguous groups).
 For the sake of good performance, we use array resizing
 to guarantee that the load factor is between $\frac{1}{8}$
-and $\frac{1}{2}$ : this allows us to avoid too long clusters.
+and $\frac{1}{2}$: this allows us to avoid too long clusters.
 The \lstinline|resize| method is given below.
 
-\begin{lstlisting}
-private void resize(int cap) {
-	LinearProbingHashST<Key, Value> t;
-	t = new LinearProbingHashST<Key, Value>(cap);
-	for(int i = 0; i < M; i++) {
-		if(keys[i] != null) {
-			t.put(keys[i], vals[i]);			
-		}		
-	}
-		
-	keys = t.keys;
-	vals = t.vals;
-	M = t.M;	
-}
-\end{lstlisting}
+\lstinputlisting{code/Resize.java}
 
 
 \subsection{Summary}
 The cost-summary for symbol-tables implementations is given
-in table \ref{tab:cost-summary-searching}.
+in \tabref{cost-summary-searching}.
 
 % auto-generated from here http://www.tablesgenerator.com/ #flemme
 \begin{table}[ht]
 \centering
-\begin{tabular}{c|ccccc}
-\multirow{2}{*}{\begin{tabular}[c]{@{}c@{}}algorithm \\(data structure)\end{tabular}} &
-\multicolumn{2}{c}{\begin{tabular}[c]{@{}c@{}}worst-case cost\\ (after N inserts)\end{tabular}} &
-\multicolumn{2}{c}{\begin{tabular}[c]{@{}c@{}}average-case cost\\ (after N random inserts)\end{tabular}} &
-\multirow{2}{*}{\begin{tabular}[c]{@{}c@{}}efficiently support\\ordered operations?\end{tabular}} \\
+\begin{tabular}{c|cccc|c}
+\multirow{2}{*}{\begin{tabular}[c]{@{}c@{}}algorithm \\(data
+structure)\end{tabular}} &
+\multicolumn{2}{c}{\begin{tabular}[c]{@{}c@{}}worst-case cost\\ (after N
+inserts)\end{tabular}} &
+\multicolumn{2}{c|}{\begin{tabular}[c]{@{}c@{}}average-case cost\\ (after N
+random inserts)\end{tabular}} &
+\multirow{2}{*}{\begin{tabular}[c]{@{}c@{}}efficiently supports\\ordered
+operations?\end{tabular}} \\
+\cline{2-5}
 & search & insert & search hit & insert &  \\ \hline
 \begin{tabular}[c]{@{}c@{}}sequential search\\
 (unordered linked list)\end{tabular} & $N$ & $N$ & $N/2$ & $N$ & no  \\
-\begin{tabular}[c]{@{}c@{}}binary search\\ 
-(ordered array)\end{tabular} & $\log N$ & $N$ & $\log N$ & $N/2$ & yes \\
-\begin{tabular}[c]{@{}c@{}}binary tree search\\ 
-(BST)\end{tabular} & $N$ & $N$ & $1.39 \log N$ & $1.39 \log N$ & yes \\
+\cline{1-1}
+\begin{tabular}[c]{@{}c@{}}binary search\\
+(ordered array)\end{tabular} & $\lg N$ & $N$ & $\lg N$ & $N/2$ & yes \\
+\cline{1-1}
+\begin{tabular}[c]{@{}c@{}}binary tree search\\
+(BST)\end{tabular} & $N$ & $N$ & $1.39 \ln N$ & $1.39 \ln N$ & yes \\
+\cline{1-1}
 \begin{tabular}[c]{@{}c@{}}2-3 tree search\\
-(red-black BST)\end{tabular} & $2 \log N$ & $2 \log N$ & $1.00 \log N$ & $1.00 \log N$ & yes \\                                                                                                 
+(red-black BST)\end{tabular} & $2 \lg N$ & $2 \lg N$ & $1.00 \lg N$ & $1.00 \lg
+N$ & yes \\
+\cline{1-1}
 \begin{tabular}[c]{@{}c@{}}separate chaining\\
 (array of lists)\end{tabular} & $N$ & $N$ & $\frac{N}{2M}$ & $N/M$ & no \\
+\cline{1-1}
 \begin{tabular}[c]{@{}c@{}}linear probing\\
-(parallel arrays)\end{tabular} & $N$ & $N$ & $< 1.50$ & $< 2.50$ & no                                                                                                 
+(parallel arrays)\end{tabular} & $N$ & $N$ & $< 1.50$ & $< 2.50$ & no
 \end{tabular}
 \caption{Cost summary for symbol-table implementations.}
 \label{tab:cost-summary-searching}
@@ -1348,296 +1027,233 @@ in table \ref{tab:cost-summary-searching}.
 \section{Strings}
 \subsection{Tries}
 \paragraph{Goals}
-As with sorting, we can take advantage of properties of strings to develop search meth-
-ods (symbol-table implementations) that can be more efficient for typical applications where search keys are strings.
-More specifically, the goals are the next-ones: 
+As with sorting, we can take advantage of properties of strings to develop
+search methods (symbol-table implementations) that can be more efficient for
+typical applications where search keys are strings. More specifically, the
+goals are the following ones:
+
 \begin{itemize}
-\item{Search hits take time proportional to the length of the search key.}
-\item{Search misses involve examining only a few characters.}
+\item{search hits take time proportional to the length of the search key;}
+\item{search misses involve examining only a few characters.}
 \end{itemize}
 
-To achieve it, we have to adjust the symbol-table API (cfr fig \ref{triesAPI}) to provide specific character-based operations for string keys.
+To achieve them, we have to adjust the symbol-table API (\figuref{triesAPI}) to
+provide specific character-based operations for string keys.
 
 \begin{figure}[ht!]
 \centering
 \includegraphics[width=.7\linewidth]{img/APItries.png}
-\caption{Tries API}
-\label{triesAPI}
+\caption{Tries API.}
+\label{fig:triesAPI}
 \end{figure}
 
-Considering the following example keys: she sells sea
-shells by the sea shore ,let's focus on the addition of three new method: \begin{itemize}
-\item{\textbf{{\textit{longuestPrefixOf()}}}: takes a string as argument and returns the longest
-key in the symbol table that is a prefix of that string. For the given keys,
-longestPrefixOf("shell") is she and longestPrefixOf("shellsort") is
-shells .}
-\item{\textbf{{\textit{keysWithPrefix()}}} takes a string as argument and returns all the keys
-in the symbol table having that string as prefix. For the given keys,
-keysWithPrefix("she") is she and shells , and keysWithPrefix("se") is
-sells and sea .}
-\item{\textbf{{\textit{keysThatMatch()}}} takes a string as argument and returns all the keys in the
-symbol table that match that string, in the sense that a period (.) in the argu-
-ment string matches any character. For the given keys, keysThatMatch(".he")
-returns she and the , and keysThatMatch("s..") returns she and sea .}
+Considering the following example keys:
+\lstinline|she sells sea shells by the sea shore|. Let's focus on the addition
+of three new methods.
+
+\begin{itemize}
+\item{\lstinline$longuestPrefixOf()$ takes a string as argument and returns the
+longest key in the symbol table that is a prefix of that string. For the given
+keys, \lstinline$longestPrefixOf("shell")$ is \lstinline$she$ and
+\lstinline$longestPrefixOf("shellsort")$ is \lstinline$shells$.}
+\item{\lstinline$keysWithPrefix()$ takes a string as argument and returns all
+the keys in the symbol table having that string as prefix. For the given keys,
+\lstinline$keysWithPrefix("she")$ is \lstinline$she$ and \lstinline$shells$,
+and \lstinline$keysWithPrefix("se")$ is \lstinline$sells$ and \lstinline$sea$.}
+\item{\lstinline$keysThatMatch()$ takes a string as argument and returns all
+the keys in the symbol table that match that string, in the sense that a period
+(\lstinline$.$) in the argument string matches any character. For the given
+keys, \lstinline$keysThatMatch(".he")$ returns \lstinline$she$ and
+\lstinline$the$, and \lstinline$keysThatMatch("s..")$ returns \lstinline$she$
+and \lstinline$sea$.}
 \end{itemize}
 
-\subsubsection{Basic Tries}
+\subsubsection{Basic tries}
 
-\begin{mydef}[Tries]
-A \textit{trie} is a search tree build from the characters of the string keys that allows us to use the characters of the search key to guide the search. A trie has the same structure as a search tree. We usually omit null links due to a substantial number of these one. Each node corresponds to a character value (except the root) and is associated to a value, which can be \textit{null} or the value associated to one of the string key of the symbol table. A representation is given fig \ref{Basic trie}.
+\begin{mydef}[Trie]
+A \textit{trie} is a search tree built from the characters of the string keys
+that allows us to use the characters of the search key to guide the search. A
+trie has the same structure as a search tree. We usually omit null links due to
+a substantial number of these ones. Each node corresponds to a character value
+(except the root) and is associated to a value, which can be \textit{null} or
+the value associated to one of the string keys of the symbol table. A
+representation is given in \figuref{basic_trie}.
 \end{mydef}
 
 
 \begin{figure}[ht!]
 \centering
 \includegraphics[width=.4\linewidth]{img/tries.png}
-\caption{Basic trie}
-\label{Basic trie}
+\caption{Basic trie.}
+\label{fig:basic_trie}
 \end{figure}
 
 \paragraph{Search}
-Due to this organisation, search in tree is very easy: beginning at the root, following the path made by the characters inside the nodes until reaching the last character of the key is the only thing you have to do. Null links may be found if the next desired character isn't in the trie. Three results can occur:
+Due to this organisation, \emph{search} in tries is very easy: beginning at the
+root, following the path made by the characters inside the nodes until reaching
+the last character of the key is the only thing you have to do. Null links may
+be found if the next desired character isn't in the trie. Three results can
+occur:
+
 \begin{itemize}
-\item{The value at the node corresponding to the last character in the key is not null: this result is
-a \textbf{search hit}. The value associated with the key is the value in the node corre-
-sponding to its last character.}
-\item{The value in the node corresponding to the last character in the key is null (as
-in the search for shell depicted at top right above). This result is a \textbf{search miss}:
-the key is not in the table.}
-\item{The search terminated with a null link (as in the search for shore depicted at
-bottom right above). This result is also a \textbf{search miss}.}
+\item{The value at the node corresponding to the last character in the key is
+not \lstinline$null$: this result is a \textbf{search hit}. The value
+associated with the key is the value in the node corresponding to its last
+character.}
+\item{The value in the node corresponding to the last character in the key is
+\lstinline$null$ (as in the search for \lstinline$shell$ depicted in the top
+right of \figuref{basic_trie}). This result is a \textbf{search miss}: the key
+is not in the table.}
+\item{The search terminated with a null link (as in the search for
+\lstinline$shore$ depicted in the bottom right of \figuref{basic_trie}). This
+result is also a \textbf{search miss}.}
 \end{itemize}
 
-\paragraph{Node Representation}
+\paragraph{Node representation}
 \begin{itemize}
 	\item{Every node has R links, one for each possible character.}
 	\item{Characters and keys are implicitely stored in the data structure.}
 \end{itemize}
 
-An example of search is given fig \ref{Search in a basic trie}.
+An example of search is given in \figuref{basic_trie_search}.
 
 \begin{figure}[ht!]
 \centering
 \includegraphics[width=.75\linewidth]{img/trieSe.png}
-\caption{Search in a basic trie}
-\label{Search in a basic trie}
+\caption{Search in a basic trie.}
+\label{fig:basic_trie_search}
 \end{figure}
 
 \paragraph{Insertion}
-To insert a value, we begin by doing a search: we go down the trie, guided by the character of the key. Two situations can occur:
+To insert a value, we begin by doing a search: we go down the trie, guided by
+the character of the key. Two situations can occur:
+
 \begin{itemize}
-\item{\textbf{Null link encountered}: a null link is encountered before reaching the last character of the key. This implies that there is no node corresponding to this one and we have thus to create a new node for each remaining character of the key. The value is set in the node of the last character.}
-\item{\textbf{Last character encountered}: the last character of the key is encountered before reaching a null link. We just have to set the node's value to the value corresponding to the key.}
+\item{\textbf{Null link encountered}: a null link is encountered before
+reaching the last character of the key. This implies that there is no node
+corresponding to this one and we thus have to create a new node for each
+remaining character of the key. The value is set in the node of the last
+character.}
+\item{\textbf{Last character encountered}: the last character of the key is
+encountered before reaching a null link. We just have to set the node's value
+to the value corresponding to the key.}
 \end{itemize}
 
-An example of insertion in a basic trie is given fig \ref{Insertion in a basic trie}.
+An example of insertion in a basic trie is given in
+\figuref{basic_trie_insertion}.
 
 \begin{figure}[ht!]
 \centering
-\includegraphics[width=.4\linewidth]{img/trieIn1.png}
-\includegraphics[width=.3\linewidth]{img/trieIn2.png}
+\includegraphics[width=.4\linewidth]{img/trieIn1.png}\hfill
+\includegraphics[width=.3\linewidth]{img/trieIn2.png}\hfill
 \includegraphics[width=.4\linewidth]{img/trieIn3.png}
-\caption{Insertion in a basic trie}
-\label{Insertion in a basic trie}
+\caption{Insertion in a basic trie.}
+\label{fig:basic_trie_insertion}
 \end{figure}
 
 \paragraph{Implementation}
-A implementation of a trie is given below:
-\begin{lstlisting}
-public class TrieST<Value>
-{
-
-   private static int R = 256; // radix or number of possible characters
-   private Node root;
-   // root of trie
-
-   private static class Node
-   {
-	private Object val;
-	private Node[] next = new Node[R];
-   }
-
-   public Value get(String key)
-   {
-	Node x = get(root, key, 0);
-	if (x == null) return null;
-	return (Value) x.val;
-   }
-
-   private Node get(Node x, String key, int d)
-   { // Return value associated with key in the subtrie rooted at x.
- 	if (x == null) return null;
-	if (d == key.length()) return x;
-	char c = key.charAt(d); // Use dth key char to identify subtrie.
-	return get(x.next[c], key, d+1);
-   }
-
-   public void put(String key, Value val)
-   { root = put(root, key, val, 0); }
-
-   private Node put(Node x, String key, Value val, int d)
-   { // Change value associated with key if in subtrie rooted at x.
-	if (x == null) x = new Node();
-	if (d == key.length()) { x.val = val; return x; }
-	char c = key.charAt(d); // Use dth key char to identify subtrie.
-	x.next[c] = put(x.next[c], key, val, d+1);
-	return x;
-  }
-}
-\end{lstlisting}
+An implementation of a trie is given below:
+\lstinputlisting{code/TrieST.java}
 
 \paragraph{Collecting keys}
-Because keys are represented implicitly in the trie, it is difficult to provide user the ability to iterate through the keys. We do not use a queue to stock the different keys as with the binary search tree but we create an explicit representation of all the string keys using the recursive method \textit{collect()}. This method visits the different nodes and appends the corresponding characters to create the keys. The \textit{collect()} method is used to implement the \textit{keysWithPrefix()} method which is used to implement the \textit{keys()} method. The last one allows to create all the different keys (exemple given fig \ref{keysRe}). An implementation of the  \textit{collect()}, \textit{keysWithPrefix} and \textit{keys()} methods are given below: 
+Because keys are represented implicitly in the trie, it is difficult to provide
+the user with the ability to iterate through the keys. We do not use a queue to
+store the different keys as with the binary search tree but we create an
+explicit representation of all the string keys using the recursive method
+\lstinline$collect()$. This method visits the different nodes and appends the
+corresponding characters to create the keys. The \lstinline$collect()$ method
+is used to implement the \lstinline$keysWithPrefix()$ method which is used to
+implement the \lstinline$keys()$ method. The last one allows to create all the
+different keys (example given in \figuref{keysRe}). An implementation of the
+\lstinline$collect()$, \lstinline$keysWithPrefix()$ and \lstinline$keys()$
+methods is given below:
 
-\begin{lstlisting}
-public Iterable<String> keys()
-{ return keysWithPrefix(""); }
+\lstinputlisting{code/KeysWithPrefix.java}
 
-public Iterable<String> keysWithPrefix(String pre)
-{
-	Queue<String> q = new Queue<String>();
-	collect(get(root, pre, 0), pre, q);
-	return q;
-}
+The \lstinline$keysThatMatch()$ method uses a similar process, but adds an
+argument to specify the pattern to collect. A possible implementation is given
+below:
 
-private void collect(Node x, String pre, Queue<String> q)
-{
-	if (x == null) return;
-	if (x.val != null) q.enqueue(pre);
-	for (char c = 0; c < R; c++)
-		collect(x.next[c], pre + c, q);
-}
-\end{lstlisting} 
+\lstinputlisting{code/KeysThatMatch.java}
 
-The \textit{keysThatMatch()} method uses the similar process, but adds an argument to specify the pattern to collect. A possible implementation is given below:
+The \lstinline$longestPrefixOf()$ method first looks for the biggest length
+found for a path that matches with the parameter string and then returns a
+substring with the obtained length. See code below:
 
-\begin{lstlisting}
-public Iterable<String> keysThatMatch(String pat)
-{
-	Queue<String> q = new Queue<String>();
-	collect(root, "", pat, q);
-	return q;
-}
-
-public void collect(Node x, String pre, String pat, Queue<String> q)
-{
-	int d = pre.length();
-	if (x == null) return;
-	if (d == pat.length() && x.val != null) q.enqueue(pre);
-	if (d == pat.length()) return;
-	char next = pat.charAt(d);
-	for (char c = 0; c < R; c++)
-		if (next == '.' || next == c)
-			collect(x.next[c], pre + c, pat, q);
-}
-\end{lstlisting}
-
-The \textit{longuestPrefix()} method first looks for the biggest length found for a path that matches with the parameter string and then returns a substring with the obtained length. See code below:
-
-\begin{lstlisting}
-public String longestPrefixOf(String s)
-{
-	int length = search(root, s, 0, 0);
-	return s.substring(0, length);
-}
-
-private int search(Node x, String s, int d, int length)
-{
-	if (x == null) return length;
-	if (x.val != null) length = d;
-	if (d == s.length()) return length;
-	char c = s.charAt(d);
-	return search(x.next[c], s, d+1, length);
-}
-\end{lstlisting}
+\lstinputlisting{code/LongestPrefixOf.java}
 
 \begin{figure}[ht!]
 \centering
 \includegraphics[width=.45\linewidth]{img/keysRe.png}
-\caption{Keys recuperation}
-\label{keysRe}
+\caption{Key recuperation.}
+\label{fig:keysRe}
 \end{figure}
 
 \paragraph{Deletion}
-AS for the insertion, the first step of a deletion is a search: the goal is to find the node corresponding to the key and set its value to null. Two situations may occur then:
-\begin{itemize}
-\item{The node has non-null link to a child. No more work is required}
-\item{All the remaining links are null. We thus have to remove the node. Caution that if doing so leaves all the links null in its parent, we need to remove that node, and so forth.}
-\end{itemize}
-A exemple is given fig \ref{trieDel}. A possible implementation is given below:
-\begin{lstlisting}
-public void delete(String key)
-{ root = delete(root, key, 0); }
+As for insertion, the first step of deletion is a search: the goal is to find
+the node corresponding to the key and set its value to null. Two situations may
+occur then:
 
-private Node delete(Node x, String key, int d)
-{
-	if (x == null) return null;
-	if (d == key.length())
-		x.val = null;
-	else
-	{
-		char c = key.charAt(d);
-		x.next[c] = delete(x.next[c], key, d+1);
-	}
-	
-	if (x.val != null) return x;
-	
-	for (char c = 0; c < R; c++)
-		if (x.next[c] != null) return x;
-	return null;
-}
-\end{lstlisting}
+\begin{itemize}
+\item{the node has a non-null link to a child. No more work is required;}
+\item{all the remaining links are null. We thus have to remove the node.
+Caution needs to be taken that if doing so leaves all the links null in its
+parent, we need to remove that node, and so forth.}
+\end{itemize}
+An example is given in \figuref{trieDel}. A possible implementation is
+given below:
+\lstinputlisting{code/TrieDelete.java}
 
 \begin{figure}[ht!]
 \centering
 \includegraphics[width=.75\linewidth]{img/trieDel.png}
-\caption{Deletion with basic trie}
-\label{trieDel}
+\caption{Deletion with basic trie.}
+\label{fig:trieDel}
 \end{figure}
 
-\begin{myprop}
-The linked structure (shape) of a trie is independent of the key in-
-sertion/deletion order: there is a unique trie for any given set of keys.
-\end{myprop}
+\begin{mypropo}
+The linked structure (shape) of a trie is independent of the key
+insertion/deletion order: there is a unique trie for any given set of keys.
+\end{mypropo}
 
-\begin{myprop}
+\begin{mypropo}
 The number of array accesses when searching in a trie or inserting
-a key into a trie is at most 1 plus the length of the key. From a theorical point of view, this implies that tries are optimal for search hit.
-\end{myprop}
+a key into a trie is at most 1 plus the length of the key. From a theorical
+point of view, this implies that tries are optimal for search hits.
+\end{mypropo}
 
-\begin{myprop}
-The average number of nodes examined for search miss in a trie
-built from N random keys over an alphabet of size R is ~log R N .
-\end{myprop}
+\begin{mypropo}
+The average number of nodes examined for a search miss in a trie
+built from $N$ random keys over an alphabet of size $R$ is $\sim \log R N$.
+\end{mypropo}
 
-\begin{myprop}
-The number of links in a trie is between RN and RNw, where w is
-the average key length. More precisely, for $N$ random keys and $w$ the average length of a key, we can proove that:
+\begin{mypropo}
+The number of links in a trie is between $RN$ and $RNw$, where $w$ is
+the average key length. More precisely, for $N$ random keys and $w$ the average
+length of a key, we can prove that:
 \begin{itemize}
-\item{When keys are short, the number of links is close to RN.}
-\item{When keys are long, the number of links
-is close to RNw.}
-\item{Therefore, decreasing R can save a huge
-amount of space.}
+\item{when keys are short, the number of links is close to $RN$;}
+\item{when keys are long, the number of links is close to $RNw$;}
+\item{therefore, decreasing $R$ can save a huge amount of space.}
 \end{itemize}
-\end{myprop}
+\end{mypropo}
 
 \paragraph{Size}
-On average, the required space for a trie is huge due to the one-way-branching that can occur. A solution to this problem is the \textit{ternary search trie}.
+On average, the required space for a trie is huge due to the one-way-branching
+that can occur. A solution to this problem is the \textit{ternary search trie}.
 
 \subsubsection{Ternary search tries (TST)}
 
-\begin{mydef}
-A \textit{ternary search trie} is a trie in which each node has a character, three links,
-and a value. The three links correspond to keys
-whose current characters are less than, equal
-to, or greater than the node’s character. In TST, characters appear explicitly in nodes: we
-find characters corresponding to keys only
-when we are traversing the middle links.
+\begin{mydef}[Ternary Search Trie (TST)]
+A \textit{ternary search trie} is a trie in which each node has a character,
+three links, and a value. The three links correspond to keys whose current
+characters are less than, equal to, or greater than the node’s character. In a
+TST, characters appear explicitly in nodes: we find characters corresponding to
+keys only when we are traversing the middle links.
 \end{mydef}
 
 \paragraph{Search}
-Due to this configuration, a search appears to be easy: we compare the
+Due to this configuration, \emph{search} appears to be easy: we compare the
 first character in the key with the character at
 the root. If it is less, we take the left link; if it is
 greater, we take the right link; and if it is equal,
@@ -1645,119 +1261,92 @@ we take the middle link and move to the next
 search key character. The algorithm is applied recursively.
 
 \paragraph{Insertion}
-The insertion is like an insertion for tries: beginning with a search and then add the value in a new node or not. A example is given fig \ref{TSTSe}.
+The insertion is like an insertion for tries: beginning with a search and then
+add the value in a new node or not. A example is given in \figuref{TSTSe}.
 
 \begin{figure}[ht!]
 \centering
 \includegraphics[width=.4\linewidth]{img/TST.png}
 \includegraphics[width=.4\linewidth]{img/TSTSe.png}
-\caption{TST representation and search}
-\label{TSTSe}
+\caption{TST representation and search.}
+\label{fig:TSTSe}
 \end{figure}
 
 Using this arrangement is equivalent to implementing
 each R-way trie node as a binary search tree that uses
 as keys the characters corresponding to non-null links.
-Continuing the correspondence, TSTs correspond to 3-way string quicksort (cfr fig \ref{TSTnode}).
+Continuing the correspondence, TSTs correspond to 3-way string quicksort
+(\figuref{TSTnode}).
 
 \begin{figure}[ht!]
 \centering
 \includegraphics[width=.75\linewidth]{img/TSTnode.png}
-\caption{Node representation of a TST}
-\label{TSTnode}
+\caption{Node representation of a TST.}
+\label{fig:TSTnode}
 \end{figure}
 
-\paragraph{Immplementation}
-A implementation is given below:
+\paragraph{Implementation}
+An implementation is given below:
 
-\begin{lstlisting}
-public class TST<Value>
-{
+\lstinputlisting{code/TST.java}
 
-private Node root;
-private class Node
-{
-	char c;
-	Node left, mid, right;
-	Value val;
-}
+\begin{mypropo}
+The number of links in a TST built from $N$ string keys of average
+length $w$ is between $3N$ and $3Nw$. This implies that the required space for
+a TST is well-over shorter than for a basic trie.
+\end{mypropo}
 
-public Value get(String key)
-// root of trie
-// character
-// left, middle, and right subtries
-// value associated with string
-// same as for tries (See page 737).
-private Node get(Node x, String key, int
-{
-	if (x == null) return null;
-	char c = key.charAt(d);
-	if(c < x.c) return get(x.left, key, d);
-	else if (c > x.c) return get(x.right, key, d);
-	else if (d < key.length() - 1)
-		return get(x.mid, key, d+1);
-	else return x;
-}
+\begin{mypropo}
+A search miss in a TST built from $N$ random string keys requires on the
+average $\sim \ln N$ character compares: a search hit or an insertion in a TST
+uses a character compare for each character in the search key.
+\end{mypropo}
 
-public void put(String key, Value val)
-{ root = put(root, key, val, 0); }
-
-private Node put(Node x, String key, Value val, int d)
-{
-	char c = key.charAt(d);
-	if (x == null) { x = new Node(); x.c = c; }
-	if(c < x.c) x.left = put(x.left, key, val, d);
-	else if (c > x.c) x.right = put(x.right, key, val, d);
-	else if (d < key.length() - 1)
-	x.mid= put(x.mid,key, val, d+1);
-	else x.val = val;
-	return x;
-}
-}
-\end{lstlisting}
-
-\begin{myprop}
-The number of links in a TST built from N string keys of average
-length w is between 3N and 3Nw. This implies that the required space for a TST is well-over shorter than for a basic trie.
-\end{myprop}
-
-\begin{myprop}
-A search miss in a TST built from N random string keys requires on the average $\sim ln N$ character compares:  search hit or an insertion in a TST uses
-a character compare for each character in the search key.
-\end{myprop}
-
-In the worst case, a node might be a full R-way node that is unbalanced, stretched out
-like a singly linked list, so we would need to multiply by a factor of R.
+In the worst case, a node might be a full R-way node that is unbalanced,
+stretched out like a singly linked list, so we would need to multiply by a
+factor of $R$.
 
 \paragraph{Alphabets}
 The prime virtue of using TSTs is that they adapt gracefully to irregularities
-in search keys. First, we usually use large alphabets  in pratictal applications. These alphabet may be a problem when using a basic tree due to a huge amount of link. With TST, we can use a 256-character ASCII encoding or a 65,536-character
-Unicode encoding without having to worry about the excessive costs of nodes with 256-
-or 65,536-way branching, and without having to determine which sets of characters are
-relevant. 
+in search keys. First, we usually use large alphabets in pratictal
+applications. These alphabets may be a problem when using a basic tree due to a
+huge amount of links. With TST, we can use a 256-character ASCII encoding or a
+65536-character Unicode encoding without having to worry about the excessive
+costs of nodes with 256- or 65536-way branching, and without having to
+determine which sets of characters are relevant.
 
 \paragraph{Prefix match, collecting keys, and wildcard match.}
-A TST represent a trie, so \textit{longuestPrefixOf()}, \textit{keys()}, \textit{keysWithPrefix()} ans \textit{keysThatMatch()} implementation can be easily adapted.
+A TST represents a trie, so \lstinline$longuestPrefixOf()$, \lstinline$keys()$,
+\lstinline$keysWithPrefix()$ and \lstinline$keysThatMatch()$ implementations
+can easily be adapted.
 
 \paragraph{Deletion}
-Deletion for a TST require more work: du to his organisation, we have to use the BST node deletion method.
+Deletion for a TST requires more work: due to this organisation, we have to use
+the BST node deletion method.
 
 \paragraph{Improvement: Hybrid TSTs}
-An easy improvement can be made by using large explicit multiway node at the root (by keeping a table of $R$ TST by example). For this method to be effective, the leading digits of the keys must be well distributed.The resulting hybrid tries 
-algorithm corresponds to the way that a human might search for names in a telephone
-book ("Beginning by 'A', before 'Andrews' but after 'Aindan'").
+An easy improvement can be made by using a large explicit multiway node at the
+root (by keeping a table of $R$ TSTs for example). For this method to be
+effective, the leading digits of the keys must be well distributed. The
+resulting hybrid tries algorithm corresponds to the way that a human might
+search for names in a telephone book (``Beginning by `A', before `Andrews' but
+after `Aindan' '').
 
-\paragraph{One-way-branching} Just as with tries, we can make TSTs more efficient in their use of
-space by putting keys in leaves at the point where they are distinguished and by eliminating one-way branching between internal nodes. we have thus the next proposition:
-a search or an insertion in a TST built from N random string keys
-with no external one-way branching and $R^t$ -way branching at the root requires
-roughly ln N - t ln R character compares, on the average.
+\paragraph{One-way-branching}
+Just as with tries, we can make TSTs more efficient in their use of space by
+putting keys in leaves at the point where they are distinguished and by
+eliminating one-way branching between internal nodes. We have thus the next
+proposition: a \emph{search} or an insertion in a TST built from $N$ random
+string keys with no external one-way branching and R\textsuperscript{t}-way
+branching at the root requires roughly $\ln N - t \ln R$ character compares, on
+the average.
 
-\paragraph{Performance point of view}
-If space is available, R-way tries provide the fastest search, essentially completing the
-job with a constant number of character compares. For large alphabets, where space
-may not be available for R-way tries, TSTs are preferable, since they use a logarithmic
-number of character compares, while BSTs use a logarithmic number of key compares.
+\paragraph{Performance}
+If space is available, R-way tries provide the fastest search, essentially
+completing the job with a constant number of character compares. For large
+alphabets, where space may not be available for R-way tries, TSTs are
+preferable, since they use a logarithmic number of character compares, while
+BSTs use a logarithmic number of key compares.
 
 \begin{figure}[ht!]
 \centering
@@ -1772,7 +1361,7 @@ a pattern string of length $M$, find an occurence
 of the pattern within the text.
 \end{myprob}
 
-\subsubsection{Rabin-Karp finger print search}
+\subsubsection{Rabin-Karp fingerprint search}
 The Rabin-Karp algorithm uses hashing to solve this problem.
 It's almost as simple as the brute-force algorithm but
 runs in time proportional to $M+N$ with very high probability.
@@ -1780,18 +1369,18 @@ Furthermore, this algorithm extends to two-dimensional patterns,
 which makes it more useful than the others for image processing.
 
 \paragraph{Basic idea}
-The basic idea behind this algorithm is the following : we compute
-a hash function for the pattern an then look for a match by using
-the same hash function for each possible $M$ character substring
+The basic idea behind this algorithm is the following: we compute
+a hash function for the pattern and then look for a match by using
+the same hash function for each possible $M$-character substring
 of the text. If we find a text substring with the same hash value
-as the pattern, we can check for a match. 
+as the pattern, we can check for a match.
 
 \paragraph{Key idea}
 A straightforward implementation based on this description would be much
 slower than a brute-force search (since computing a hash function that involves
 every character is likely to be much more expensive than just
 comparing characters). But Rabin and Karp showed that it is easy
-to compute hash functions for $M$-characters substrings in
+to compute hash functions for $M$-character substrings in
 constant time, which leads to a linear-time substring search.
 
 Using the notation $t_i$ for \lstinline|txt.charAt(i)|, the number
@@ -1800,7 +1389,7 @@ starts at position \lstinline|i| using Horner's method is
 
 \[ x_i = t_iR^{M-1} + t_{i+1}R^{M-2} + \dots + t_{i+M-1}R^0 \]
 
-and we can assume that we know the value of $h(x_i) = x_i\mod Q$.
+and we can assume that we know the value of $h(x_i) = x_i\bmod Q$.
 Shifting one position right in the text corresponds to replacing
 $x_i$ by
 
@@ -1809,15 +1398,15 @@ $x_i$ by
 We substract off the leading digit, multiply it by $R$, then add
 the trailing digit. Now, the crucial point is that we do not have
 to maintain the values of the numbers (i.e. $x_i$), just the
-values of theirs reminders when divided by $Q$ (i.e. $h(x_i)$).
-Remember the property of modulus operation discussed in remark
+values of their remainders when divided by $Q$ (i.e. $h(x_i)$).
+Remember the property of the modulus operation discussed in remark
 \ref{rem:mod-prop}.
 
 \paragraph{Implementation}
-Here is the implementation of the \textit{Monter Carlo}
+Here is the implementation of the \textit{Monte Carlo}
 version of the Rabin-Karp fingerprint substring search.
 
-\begin{mydef}
+\begin{mydef}[Monte Carlo and Las Vegas algorithms]
 A \textit{Monte Carlo} algorithm is a randomized algorithm
 whose running time is deterministic, but whose output may be
 incorrect with a certain probability. On the other side, a
@@ -1825,52 +1414,7 @@ incorrect with a certain probability. On the other side, a
 always gives correct results.
 \end{mydef}
 
-\begin{lstlisting}
-public class RabinKarp
-{
-	private long patHash; // pattern hash value
-	private int M; // pattern length
-	private long Q; // a large prime
-	private int R = 256; // alphabet size
-	private long RM; // R^(M-1) % Q for use in removing leading digit
-	
-	public RabinKarp(String pat) {
-		M = pat.length();
-		Q = longRandomPrime();
-		RM = 1;
-		for (int i = 1; i <= M-1; i++) {
-			RM = (R * RM) % Q;		
-		}
-		
-		patHash = hash(pat, M);
-	}
-	
-	private long hash(String key, int M) {
-		long h = 0;
-		for(int j = 0; j < M; j++) {
-			h = (R * h + key.charAt(j)) % Q;		
-		}
-		
-		return h;
-	}
-	
-	private int search(String txt) {
-		int N = txt.length();
-		long txtHash = hash(txt, M);
-		
-		if(patHash == txtHash)	return 0; // match
-		
-		for(int i = M; i < N; i++) {
-			txtHash = (txtHash + Q - RM*txt.charAt(i-M) % Q) % Q;
-			txtHash = (txtHash*R + txt.charAt(i)) % Q;
-			if(patHash == txtHash)
-				return (i - M + 1);		
-		}
-		
-		return N; // no match
-	}
-}
-\end{lstlisting}
+\lstinputlisting{code/RabinKarp.java}
 
 \begin{myrem}
 An extra \lstinline|Q| is added on line 36 to make sure that
@@ -1880,26 +1424,26 @@ it should.
 
 By choosing a value of \lstinline|Q| greater than $10^{20}$, we
 reduce the risk of collision, and thus reduce the probability
-of the Monte Carlo algorithm to fail. The alternative method
+of the Monte Carlo algorithm failing. The alternative method
 of checking for a match could be slow but is guaranteed correct.
 
 \subsection{Data compression}
 \begin{myprob}[Lossless compression]
-The objectives of data compression is to obtain two black boxes :
+The objective of data compression is to obtain two black boxes :
 \begin{itemize}
-	\item A \textit{compress} box that transforms a bitstream $B$
-	into a compressed version $C(B)$ ;
-	\item An \textit{expand} box that transforms $C(B)$ back into $B$.
+	\item a \textit{compress} box that transforms a bitstream $B$
+	into a compressed version $C(B)$;
+	\item an \textit{expand} box that transforms $C(B)$ back into $B$.
 \end{itemize}
-Using the notation $|B|$ to denote the number of bits in bitstream,
-we are interested in minimizing the quantity $|C(B)|/|B|$, which is
-known as the compression ratio.
+Using the notation $\lvert B \rvert$ to denote the number of bits in the
+bitstream, we are interested in minimizing the quantity $\lvert C(B)
+\rvert/\lvert B \rvert$, which is known as the compression ratio.
 \end{myprob}
 
-\begin{myprop}
+\begin{mypropo}
 Universal data compression is impossible, that is, no algorithm
 can compress every bitstream.
-\end{myprop}
+\end{mypropo}
 
 \subsubsection{Huffman compression}
 The idea is to abandon the way in which text files are
@@ -1921,255 +1465,289 @@ a trie. The general method for finding the optimal prefix-free
 code is the hearth of Huffman compression.
 
 \paragraph{Overview}
-To compress a bitstream :
+To compress a bitstream:
 \begin{itemize}
-	\item Read the input ;
-	\item Tabulate the frequency of occurrence of each
-	char value in the input ;
-	\item Build the Huffman encoding trie corresponding to
-	those frequencies ;
-	\item Build the corresponding codeword table to associate
-	a bitstring with each \lstinline|char| value in the input ;
-	\item Write the trie, encoded as bitstring ;
-	\item Write the count of characters in the input, encoded
-	as a bitstring ;
-	\item Use the codeword table to write the codeword for each
+	\item read the input;
+	\item tabulate the frequency of occurrence of each
+	\lstinline$char$ value in the input;
+	\item build the Huffman encoding trie corresponding to
+	those frequencies;
+	\item build the corresponding codeword table to associate
+	a bitstring with each \lstinline|char| value in the input;
+	\item write the trie, encoded as bitstring;
+	\item write the count of characters in the input, encoded
+	as a bitstring;
+	\item use the codeword table to write the codeword for each
 	input character.
 \end{itemize}
 
-To expand a bitstream :
+To expand a bitstream:
 \begin{itemize}
-	\item Read the trie (encoded at the beginning of the bistream ;
-	\item Read the count of characters to be decoded ;
-	\item Use the trie to decode the bitstream.
+	\item read the trie (encoded at the beginning of the bistream;
+	\item read the count of characters to be decoded;
+	\item use the trie to decode the bitstream.
 \end{itemize}
 
 \section{Graphs}
 
-\subsection{Graphe non-orienté}
+\subsection{Undirected graph}
 
-\paragraph{Definition}
+\begin{mydef}[Graph]
 A graph is a set of vertices and a collection of edges that each connect a
 pair of vertices.
+\end{mydef}
 
 \paragraph{Anomalies}
 Our definition allows two simple anomalies:
 \begin{itemize}
 
-\item A self-loop is an edge that connects a vertex to itself.
-\item Two edges that connect the same pair of vertices are parallel.
+\item a self-loop is an edge that connects a vertex to itself;
+\item two edges that connect the same pair of vertices are parallel.
 
 \end{itemize}
 
-
-
-\paragraph{Definition}
-
+\begin{mydef}[Path]
 A path in a graph is a sequence of vertices
-connected by edges. A simple path is one with no repeated
-vertices. A cycle is a path with at least one edge whose first
-and last vertices are the same. A simple cycle is a cycle with
-no repeated edges or vertices (except the requisite repetition
-of the first and last vertices). The length of a path or
-a cycle is its number of edges.
+connected by edges.
+\end{mydef}
+\begin{mydef}[Simple path]
+A simple path is one with no repeated vertices.
+\end{mydef}
+\begin{mydef}[Cycle]
+A cycle is a path with at least one edge whose first
+and last vertices are the same.
+\end{mydef}
+\begin{mydef}[Simple cycle]
+A simple cycle is a cycle with no repeated edges or vertices (except the
+requisite repetition of the first and last vertices).
+\end{mydef}
+\begin{mydef}[Length]
+The length of a path or a cycle is its number of edges.
+\end{mydef}
 
-\paragraph{Definition}
-
+\begin{mydef}[Connected graph]
 A graph is connected if there is a path from every vertex to every other
-vertex in the graph. A graph that is not connected consists of a set of connected components,
-which are maximal connected subgraphs.
-
-\paragraph{Definition}
-
-A tree is an acyclic connected graph. A disjoint
-set of trees is called a forest. A spanning tree of a
-connected graph is a subgraph that contains all of that
+vertex in the graph. A graph that is not connected consists of a set of
+connected components, which are maximal connected subgraphs.
+\end{mydef}
+\begin{mydef}[Acyclic graph]
+An acyclic graph is a graph with no cycles.
+\end{mydef}
+\begin{mydef}[Tree]
+A tree is an acyclic connected graph.
+\end{mydef}
+\begin{mydef}[Forest]
+A forest is a disjoint set of trees.
+\end{mydef}
+\begin{mydef}[Spanning tree]
+A spanning tree of a connected graph is a subgraph that contains all of that
 graph’s vertices and is a single tree. A spanning forest of
 a graph is the union of spanning trees of its connected
 components.
+\end{mydef}
 
-For example, a graph G with V vertices is a tree if and
+For example, a graph $G$ with $V$ vertices is a tree if and
 only if it satisfies any of the following five conditions:
 
 \begin{itemize}
-\item G has V-1 edges and no cycles.
-\item G has V-1 edges and is connected.
-\item G is connected, but removing any edge disconnects it.
-\item G is acyclic, but adding any edge creates a cycle.
-\item Exactly one simple path connects each pair of vertices in G.
+\item $G$ has $V-1$ edges and no cycles;
+\item $G$ has $V-1$ edges and is connected;
+\item $G$ is connected, but removing any edge disconnects it;
+\item $G$ is acyclic, but adding any edge creates a cycle;
+\item exactly one simple path connects each pair of vertices in $G$.
 \end{itemize}
 
-\paragraph{Definition}
-
+\begin{mydef}[Bipartite graph]
 A bipartite graph is a graph whose vertices we can divide into two sets
 such that all edges connect a vertex in one set with a vertex in the other
-set. The figure at right gives an example of a bipartite graph, where one
+set. An example of a bipartite graph is given in \figuref{bipart}, where one
 set of vertices is colored red and the other set of vertices is colored black.
+\end{mydef}
 
 \begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.15]{img/graph_bipart.png}
-	\caption{A bipartite graph}
+	\caption{A bipartite graph.}
 	\label{fig:bipart}
 \end{figure}
 
-\subsubsection{Différents types de représentations des graphes}
+\subsubsection{Different types of graph representations}
 
-Il y en a 3: 
+Different data structures exist:
 \begin{itemize}
-\item une liste de liens
-\item une matrice d'adjascence
-\item une liste d'adjascence 
+\item an incidence matrix;
+\item an adjacency matrix;
+\item an adjacency list.
 \end{itemize}
 
-Les complexités des méthodes \texttt{adj(int v)} et \texttt{addEdge(int v, int w)} sont les suivantes: 
+\lstinline$adj(int v)$ is a method that allows iterating through the vertices
+adjacent to a vertex \lstinline$v$.
+
+The complexities of \lstinline$adj(int v)$ and
+\lstinline$addEdge(int v, int w)$ are as follows:
 
 \vspace{0.3cm}
-\begin{tabular}{|c|c|c|c|}
+\begin{tabular}{c|ccc}
+& \textbf{Incidence matrix} & \textbf{Adjacency matrix} & \textbf{Adjacency
+list}\\
 \hline
-& \textbf{Liste de liens} & \textbf{Matrice d'adjascence} & \textbf{Listes d'adjascence }\\
-\hline
-\textbf{adj(int v)} & O(m) & O(n) & O(1) 
-\\
-\textbf{addEdge(int v, int w)} & O(1) & O(1)& O(1)
-\\
-\hline
+\lstinline$adj(int v)$ & $\bigoh(\lvert E \rvert)$ & $\bigoh(1)$ &
+$\bigoh(\lvert V \rvert)$\\
+\lstinline$addEdge(int v, int w)$ & $\bigoh(\lvert V \rvert \cdot \lvert E
+\rvert)$ & $\bigoh(1)$ & $\bigoh(1)$\\
 \end{tabular}
-\subsubsection{Graph Data Type}
-The graph data type is made of three important local variables: an integer variable \texttt{V} for the number of vertices, an integer variable \texttt{E} for the number of edges and last but not least: an adjacency lists represented by a \texttt{Bag<Integer>[]} array.
 
-\subsubsection{DepthFirstSearch}
+\subsubsection{Undirected graph data type}
+The undirected graph data type is made of three important local variables: an
+integer variable \lstinline$V$ for the number of vertices, an integer variable
+\lstinline$E$ for the number of edges and last but not least: an adjacency list
+represented by a \lstinline$Bag<Integer>[]$ array.
 
-The classic recursive method for searching in a connected graph (visiting all of its vertices and edges) mimics Tremaux maze exploration but is even simpler to describe. To search a graph, invoke a recursive method that visits vertices. To visit a vertex:
+\subsubsection{Depth-first search (DFS)}
+The classic recursive method for searching in a connected graph (visiting all
+of its vertices and edges) mimics Tr\'emaux's algorithm but is even simpler to
+describe. To search a graph, invoke a recursive method that visits vertices. To
+visit a vertex:
 	\begin{itemize}
-		\item Mark it as having been visited.
-		\item Visit (recursively) all the vertices that are adjacent to it and have not yet been marked.
+		\item mark it as having been visited;
+		\item visit (recursively) all the vertices that are adjacent to it
+		and have not yet been marked.
 	\end{itemize}
 
-The DFS algorithm below maintains an array of \texttt{boolean} values to mark all of the vertices that are connected to the source (variable \texttt{s}).
+The DFS algorithm below maintains an array of \lstinline$boolean$ values to
+mark all of the vertices that are connected to the source (variable
+\lstinline$s$).
 
 \lstinputlisting{code/DepthFirstSearch.java}
 
-\subsubsection{DepthFirstPath}
+\subsubsection{Depth-first path}
 
-This \texttt{Graph} client uses depth-first search to find paths to all the vertices in a graph that are connected to a given start vertex \texttt{s}.
+This \lstinline$Graph$ client uses depth-first search to find paths to all the
+vertices in a graph that are connected to a given start vertex \lstinline$s$.
 You will notice that the major part of this code is from the DFS.
 
 \lstinputlisting{code/DepthFirstPath.java}
 
-
 \begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.5]{img/dfp.png}
-	\caption{Trace of pathTo(5) computation}
+	\caption{Trace of \lstinline$pathTo(5)$ computation.}
 	\label{fig:dfp}
 \end{figure}
 
-\subsection{Graphes orientés}
+\subsection{Directed graph}
 
-\paragraph{Definition}
-
+\begin{mydef}[Directed graph]
 A directed graph (or digraph) is a set of vertices and a collection of directed
 edges. Each directed edge connects an ordered pair of vertices.
+\end{mydef}
 
-\paragraph{Definition}
+\begin{mydef}[Directed path]
+A directed path in a digraph is a sequence of vertices in which there is a
+(directed) edge pointing from each vertex in the sequence to its successor in
+the sequence.
+\end{mydef}
+\begin{mydef}[Directed cycle]
+A directed cycle is a directed path with at least one edge whose first and last
+vertices are the same.
+\end{mydef}
 
-A directed path in a digraph is a sequence of vertices in which there is
-a (directed) edge pointing from each vertex in the sequence to its successor in the
-sequence. A directed cycle is a directed path with at least one edge whose first and
-last vertices are the same. A simple cycle is a cycle with no repeated edges or vertices
-(except the requisite repetition of the first and last vertices). The length of a path or
-a cycle is its number of edges.
-
-\subsubsection{DirectedDFS}
+\subsubsection{Directed DFS}
 
 \lstinputlisting{code/DirectedDFS.java}
-\underline{Note:} the \texttt{!marked[s]} condition in the \texttt{DirectedDFS} constructor is useless since the boolean array was created just before and thus all its entries are set to false...
-\subsubsection{DirectedCycle}
+\paragraph{Note}
+The \lstinline$!marked[s]$ condition in the \lstinline$DirectedDFS$ constructor
+is useless since the \lstinline$boolean$ array was created just before and thus
+all its entries are set to false\dots
 
-\paragraph{Definition}
+\subsubsection{Directed cycle}
 
+\begin{mydef}[Directed acyclic graph (DAG)]
 A directed acyclic graph (DAG) is a digraph with no directed cycles.
-\\
+\end{mydef}
 
-This class adds to our standard recursive dfs() a boolean array onStack[] to keep track of the vertices
-for which the recursive call has not completed. When it finds an edge v->w to a vertex w that is on
-the stack, it has discovered a directed cycle, which it can recover by following edgeTo[] links.
+This class adds to our standard recursive \lstinline$dfs()$ a
+\lstinline$boolean$ array \lstinline$onStack[]$ to keep track of the vertices
+for which the recursive call has not completed. When it finds an edge
+\lstinline$v-w$ to a vertex \lstinline$w$ that is on the stack, it has
+discovered a directed cycle, which it can recover by following
+\lstinline$edgeTo[]$ links.
 
 \lstinputlisting{code/DirectedCycle.java}
 
 \begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.8]{img/directed_cycle.png}
-	\caption{Trace of cycle computation	}
+	\caption{Trace of cycle computation.}
 	\label{fig:directed cycle}
 \end{figure}
 
-\subsubsection{Tri topologique}
+\subsubsection{Topological sort}
 
-\paragraph{Proposition}
+\begin{mypropo}
 A digraph has a topological order if and only if it is a DAG.
+\end{mypropo}
 
-Three vertex orderings are
-of interest in typical applications:
+Three vertex orderings are of interest in typical applications:
 
 \begin{itemize}
-\item Preorder : Put the vertex on a queue before the recursive calls.
-\item Postorder : Put the vertex on a queue after the recursive calls.
-\item Reverse postorder : Put the vertex on a stack after the recursive calls.
-
+\item preorder : put the vertex on a queue before the recursive calls;
+\item postorder : put the vertex on a queue after the recursive calls;
+\item reverse postorder : put the vertex on a stack after the recursive calls.
 \end{itemize}
 
 \begin{figure}[H]
 	\centering
-	\includegraphics[scale=1]{img/pre_post_rev.png}
-	\caption{Computing depth-first orders in a digraph}
-	\label{fig:directed cycle}
+	\includegraphics[width=\textwidth]{img/pre_post_rev.png}
+	\caption{Computing depth-first orders in a digraph.}
+	\label{fig:dfs_digraph}
 \end{figure}
 
-
-
-A
-one-line addition to our standard recursive DFS does the job! To convince you of this
-fact, we begin with the class DepthFirstOrder
+A one-line addition to our standard recursive DFS does the job! To convince
+yourself of this fact, begin with the class \lstinline$DepthFirstOrder$
 
 \lstinputlisting{code/DFSOrder.java}
 
 \lstinputlisting{code/TopologicalSort.java}
 
-\subsection{Minimum Spanning Trees}
+\subsection{Minimum Spanning Tree}
 
-\paragraph{Definition}
+\begin{mydef}[Edge-weighted graph]
+With each edge $e$ of $G$ let there be associated a real number $w(e)$, called
+its weight. Then $G$, together with these weights on its edges, is called an
+edge-weighted graph (or a weighted graph).
+\end{mydef}
 
-A minimum spanning tree (MST ) of an
+\begin{mydef}[Minimum Spanning Tree (MST)]
+A minimum spanning tree (MST) of an
 edge-weighted graph is a spanning tree whose weight
 (the sum of the weights of its edges) is no larger than
 the weight of any other spanning tree.
+\end{mydef}
 
-\paragraph{Definition}
+\begin{mydef}[Cut]
 A cut of a graph is a partition of its vertices into two nonempty disjoint
-sets. A crossing edge of a cut is an edge that connects a vertex in one set with a vertex
-in the other.
+sets. A crossing edge of a cut is an edge that connects a vertex in one set
+with a vertex in the other.
+\end{mydef}
 
-\paragraph{Edge-weighted graph data type}:
+\paragraph{Edge-weighted graph data type}
 
 \begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.7]{img/edge_w_api.png}
-	
 	\label{fig:edge w api}
 \end{figure}
 
-\paragraph{Cut Property}
-
-Given any cut in an edgeweighted
+\begin{mypropo}
+Given any cut in an edge-weighted
 graph, the crossing edge of minimum weight is in
 the MST of the graph.
+\end{mypropo}
 
 \subsubsection{Prim's algorithm}
 
-Prim’s algorithm computes the MST of any
-connected edge-weighted graph.
+Prim's algorithm computes the MST of any connected edge-weighted graph.
 
 \lstinputlisting{code/LazyPrimMST.java}
 
@@ -2182,23 +1760,21 @@ connected edge-weighted graph.
 \begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.8]{img/summary_mst.png}
-	
 	\label{fig:summary MST}
-
-
 \end{figure}
-\underline{Note:} Kruskal's algorithm is generally slower than Prim's algorithm because it has to do a \texttt{connected()} operation for each edge, in addition to the priority-queue operations that both algorithms do for each edge processed.
 
+\begin{myrem}
+Kruskal's algorithm is generally slower than Prim's algorithm because it has to
+do a \lstinline$connected()$ operation for each edge, in addition to the
+priority-queue operations that both algorithms do for each edge processed.
+\end{myrem}
 
 \subsection{Shortest path}
 
 \begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.5]{img/directed_edge_w_api.png}
-	
 	\label{fig:directed w edge api}
-
-
 \end{figure}
 
 
@@ -2210,23 +1786,19 @@ connected edge-weighted graph.
 \begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.5]{img/summary_SPT.png}
-	
 	\label{fig:summary spt}
-
-
 \end{figure}
-
 
 % Need a better title for this section
 \section{Various algorithms}
 \subsection{Union-find}
-\begin{mydef}
+\begin{mydef}[Union-find data structure]
 A \textit{union-find} data structure is a data structure
-that keeps track of a set of elements partitionned into
+that keeps track of a set of elements partitioned into
 a number of disjoint subsets (equivalence classes).
 \end{mydef}
 
-The API is given in figure \ref{fig:uf-api}.
+The API is given in \figuref{uf-api}.
 
 \begin{figure}[ht]
 	\centering
@@ -2235,16 +1807,16 @@ The API is given in figure \ref{fig:uf-api}.
 	\label{fig:uf-api}
 \end{figure}
 
-This data structure helps to solve \textit{dynamic
+This data structure helps to solve the \textit{dynamic
 connectivity} problem. This problem arises for example
 in networks. We will use networking terminology here.
-We refer to the objects as \textit{sites}, the paires
-as \textit{connections} et equivalence classes as
+We refer to the objects as \textit{sites}, the pairs
+as \textit{connections} and the equivalence classes as
 \textit{connected components} or \textit{components}.
 
 When studying algorithms to implement the union-find API,
 we count array accesses (the number of times an array entry
-is accessed, for read or write).
+is accessed, for \emph{read} or \emph{write}).
 
 We will consider three different implementations, all based
 on using a site-indexed \lstinline|id[]| array.
@@ -2254,52 +1826,23 @@ Here we maintain the invariant that \lstinline|p| and
 \lstinline|q| are connected if and only if \lstinline|id[p]|
 is equal to \lstinline|id[q]|. Implementation is quite
 straightforward. An overview of quick-find is given
-in figure \ref{fig:quick-find-overview}.
+in \figuref{quick-find-overview}.
 
-\begin{lstlisting}
-public class UF {
-	private int[] id;	// access to component id (site indexed)
-	private int count;	// number of components
-	
-	public UF(int N) {
-		count = N;
-		id = new int[N];
-		for(int i = 0; i < N; i++) {
-			id[i] = i;		
-		}	
-	}
-	
-	public int count() { return count; }
-	public boolean connected(int p, int q) { return find(p) == find(q);	}
-	public int find(int p) {return id[p];}
-	
-	public void union(int p, int q) {
-		int pID = find(p);
-		int qID = find(q);
-		
-		if(pID == qID) return;
-		
-		for(int i = 0; i < id.length; i++)
-			if(id[i] == pID) id[i] = qID;		
-		
-		count--;
-	}
-}
-\end{lstlisting}
+\lstinputlisting{code/UnionFind.java}
 
 \begin{myrem}
 Note that here we made the arbitrary choice of
 renaming the component containing \lstinline|p|.
 \end{myrem}
 
-\begin{myprop}
+\begin{mypropo}
 The quick-find algorithm uses one array access for
 each call to \lstinline|find()|, two array accesses
 for each call to \lstinline|connected()| and
 between $N+3$ and $2N+1$ array accesses for
 each call to \lstinline|union()| that combines
 two components.
-\end{myprop}
+\end{mypropo}
 
 \begin{figure}[ht]
 	\centering
@@ -2313,114 +1856,69 @@ Here, the \lstinline|id[i]| entry for each site
 is the name of another site in the same component
 (possibly itself, in this case we call it a
 \textit{root}) - we refer to this connection as a
-\textit{link} To implement \lstinline|find()|,
+\textit{link}. To implement \lstinline|find()|,
 we start at the given site, follow its link to
 another site, follow that site's link to yet
 another site and so forth until reaching a root.
 An overview of quick-union is given
-in figure \ref{fig:quick-union-overview}.
+in \figuref{quick-union-overview}.
 
-\begin{lstlisting}
-public int find(int p) {
-	while (p != id[p]) p = id[p];
-	return p;
-}
-\end{lstlisting}
+\lstinputlisting{code/Find.java}
 
 Two sites are in the same component if and
 only if this process leads them to the same
 root.
 
-\begin{lstlisting}
-public void union(int p, int q) {
-	int i = find(p);
-	int i = find(q);
-	if (i == j) return;
-	
-	// Make root of the first tree point to the second
-	id[i] = j;
-	count--;
-}
-\end{lstlisting}
+\lstinputlisting{code/Union.java}
 
 \begin{figure}[ht]
 	\centering
 	\includegraphics[scale=0.55]{img/quick-union-overview.png}
-	\caption{Quick-union overview}
+	\caption{Quick-union overview.}
 	\label{fig:quick-union-overview}
 \end{figure}
 
-On figure \ref{fig:quick-union-overview}, we use the
+In \figuref{quick-union-overview}, we use the
 \textit{forest-of-trees} representation. With this
 representation, we can define some terminology.
 
-\begin{mydef}
-The \textit{size} of a tree is its number of notes. The
-\textit{depth} of a node in a tree is the number of links on the
-path from it to the root. The \textit{height} of a tree is
-the maximum depth among its nodes.
+\begin{mydef}{Size}
+The \textit{size} of a tree is its number of nodes.
+\end{mydef}
+\begin{mydef}{Depth}
+The \textit{depth} of a node in a tree is the number of links on the
+path from it to the root.
+\end{mydef}
+\begin{mydef}{Height}
+The \textit{height} of a tree is the maximum depth among its nodes.
 \end{mydef}
 
-\begin{myprop}
+\begin{mypropo}
 The number of array accesses used by \lstinline|find()| in
 quick-union is 1 plus twice the depth of the node corresponding
-to the given site. The number of array accessed used by
+to the given site. The number of array accesses used by
 \lstinline|union()| and \lstinline|connected()| is the cost
 of the two \lstinline|find()| operations (plus 1 for \lstinline|union()|
 if the given sites are in different trees).
-\end{myprop}
+\end{mypropo}
 
-\subsubsection{Weighted-quick-union}
-Weighted-quick-union is an improvement to quick-union algorithms
-that allow us to reduce the tree height, and thus to reduce
+\subsubsection{Weighted quick-union}
+Weighted quick-union is an improvement to quick-union algorithms
+that allow us to reduce the tree height, and thus to reduce the
 complexity of \lstinline|find()|.
 
-\begin{lstlisting}
-public class WeigthedQuickUnionUF {
-	private int[] id;	// access to component id (site indexed)
-	private int[] sz;	// size of component for roots (site indexed)
-	private int count;	// number of components
-	
-	public WeightedQuickUnionUF(int N) {
-		count = N;
-		id = new int[N];
-		for(int i = 0; i < N; i++)	id[i] = i;
-		sz = new int[N];		
-		for(int i = 	0; i < N; i++) 	sz[i} = 1;	
-	}
-	
-	public int count() { return count; }
-	public boolean connected(int p, int q) { return find(p) == find(q);	}
-	
-	public int find(int p) {
-		while(p != id[p]) p = id[p];
-		return p;
-	}
-	
-	public void union(int p, int q) {
-		int i = find(p);
-		int j = find(q);
-		if(i == j) return;
-		
-		// Make smaller root point to the larger one
-		if		(sz[i] < sz[j]) 	{ id[i] = j; sz[j] += sz[i]; }
-		else						{ id[j] = i; sz[i] += sz[j]; }
-		
-		count--;
-	}
-}
-\end{lstlisting}
+\lstinputlisting{code/WeightedQuickUnion.java}
 
-\begin{myprop}
+\begin{mypropo}
 The depth of any node in a forest built by weighted
-quick-union for $N$ sites is at most $\log N$.
-\end{myprop}
+quick-union for $N$ sites is at most $\lg N$.
+\end{mypropo}
 
 \begin{mycorr}
 For weighted quick-union with $N$ sites, the worst
 case order of growth of the cost of \lstinline|find()|,
 \lstinline|connected()| and \lstinline|union()| is
-$\log N$.
+$\lg N$.
 \end{mycorr}
 
 \subsubsection{Summary}
@@ -2428,11 +1926,11 @@ $\log N$.
 \begin{table}[ht]
 	\centering
 	\begin{tabular}{c|ccc}
-		\textbf{algorithm} & \textbf{constructor} & \textbf{union} & \textbf{find} \\
+		\textbf{Algorithm} & \textbf{Constructor} & \textbf{Union} & \textbf{Find} \\
 		\hline
-		quick-find & $N$ & $N$ & 1 \\
-		quick-union & $N$ & tree height & tree height \\
-		weigthed quick-union & $N$ & $\log N$ & $\log N$
+		Quick-find & $N$ & $N$ & 1 \\
+		Quick-union & $N$ & tree height & tree height \\
+		Weigthed quick-union & $N$ & $\lg N$ & $\lg N$
 	\end{tabular}
 	\caption{Performance characteristics of union-find algorithms.}
 	\label{tab:perf-uf}
@@ -2440,10 +1938,10 @@ $\log N$.
 
 \subsection{Priority queues}
 A priority queue is an abstract data type with the API given
-in figure \ref{fig:pq-api}. In this subsection, we will
+in \figuref{pq-api}. In this subsection, we will
 consider a \lstinline|MaxPQ|. \lstinline|MinPQ| is easily
 obtained from \lstinline|MaxPQ| (you only need to use
-min-heap instead of a max-heap, continue to read to understand).
+min-heap instead of a max-heap in what follows).
 
 \begin{figure}[ht]
 	\centering
@@ -2464,38 +1962,37 @@ are stored in an array such that each key is guaranteed to be
 larger than (or equal to) the keys at two
 other specific positions.
 
-\begin{mydef}
+\begin{mydef}[Heap-ordered binary tree]
 A binary tree is \textit{heap-ordered} if the key in each
 node is larger than or equal to the keys in that node's
 two children (if any).
 \end{mydef}
 
-\begin{myprop}
+\begin{mypropo}
 The largest key in a heap-ordered binary tree is found at
 the root.
-\end{myprop}
+\end{mypropo}
 
 \begin{mydef}[Complete binary tree]
-In a complete binary tree every level, except possibly the
+In a complete binary tree, every level, except possibly the
 last, is completely filled, and all nodes in the last level
 are as far left as possible.
 \end{mydef}
 
-A heap-ordered complete binary tree is illustrated in figure
-\ref{fig:heap}.
+A heap-ordered complete binary tree is illustrated in \figuref{heap}.
 
 \begin{figure}[ht]
 	\centering
 	\includegraphics[scale=0.55]{img/heap.png}
 	\caption{A heap-ordered complete binary tree.}
 	\label{fig:heap}
-\end{figure} 
+\end{figure}
 
 Complete trees provide the opportunity to use a compact
 array representation (instead of explicit links as
-for trees of section \ref{sec:tree}).
+for trees of \sectionref{tree}).
 
-\begin{mydef}
+\begin{mydef}[Binary heap]
 A binary heap is a collection of keys arranged in a complete
 heap-ordered binary tree, represented in level order in an
 array (not using the first entry).
@@ -2504,59 +2001,40 @@ array (not using the first entry).
 In a heap, the parent of the node in position $k$ is in
 position $\lfloor \frac{k}{2} \rfloor$ and, conversely,
 the two children of the node in position $k$ are in
-position $2k$ and $2k+1$. This allows us to travel
-up and down the tree simply by doing arithmetic on
+positions $2k$ and $2k+1$. This allows us to travel
+up and down the tree simply by doing arithmetic
 on array indices.
 
-\begin{myprop}
+\begin{mypropo}
 The height of a complete binary tree of size $N$ is
-$\lfloor \log N \rfloor$
-\end{myprop}
+$\lfloor \lg N \rfloor$
+\end{mypropo}
 
 \paragraph{Heap algorithms}
-Operations on heap could violate the heap condition.
+Operations on heaps could violate the heap condition.
 The process of restoring the heap order is called
-\textit{reheapifying}. There is two types of violation
-and thus two algorithms ro reheapify.
+\textit{reheapifying}. There are two types of violations
+and thus two algorithms to reheapify.
 
 \subparagraph{Bottom-up reheapify (swim)}
-If the heap order is violated because a node's key become
+If the heap order is violated because a node's key becomes
 larger than that node's parent's key, then we can make
 progress toward fixing the violation by exchanging the node
 with its parent (and so forth, moving up until we reach a
-node with a larger key, or the root).
+node with a larger key, or the root) as can be seen in \figuref{swim}.
 
-\begin{lstlisting}
-private void swim(int k) {
-	while(k > 1 && less(k/2, k)) {
-		exch(k/2, k);
-		k = k/2;	
-	}
-}
-\end{lstlisting}
+\lstinputlisting{code/Swim.java}
 
 \subparagraph{Top-down reheapify (sink)}
 If the heap order is violated because a node's key
-becomes smaller than one or both of that children's
-key, then we can make progress toward fixing the
+becomes smaller than one or both of that node's children's
+keys, then we can make progress toward fixing the
 violation by exchanging the node with the larger
 of its two children (and so forth, moving down until
 we reach a node with both children smaller (or equal),
-or the bottom).
+or the bottom) as can be seen in \figuref{sink}.
 
-\begin{lstlisting}
-private void sink(int k) {
-	while(2*k <= N) {
-		int j = 2*k;
-		// Make j point to the larger of the two children
-		if(j < N && less(j, j+1)) j++;	
-		if(!less(k, j)) break;
-		exch(k, j);
-		k = j;	
-	}
-}
-\end{lstlisting}
-
+\lstinputlisting{code/Sink.java}
 
 \begin{figure}[ht]
 	\centering
@@ -2564,7 +2042,7 @@ private void sink(int k) {
 		\centering
   		\includegraphics[width=.85\linewidth]{img/swim.png}
  		\caption{Swim.}
-  		\label{fig:siwm}
+  		\label{fig:swim}
 	\end{subfigure}%
 	\begin{subfigure}{.5\textwidth}
   		\centering
@@ -2580,47 +2058,22 @@ private void sink(int k) {
 Now that we can reheapify, implementing \lstinline|MaxPQ|
 is quite straightforward.
 
-\begin{lstlisting}
-public class MaxPQ<Key extends Comparable<Key>> {
-	private Key[] pq;
-	private int N = 0;
-	
-	public MaxPQ(int maxN) {
-		pq = (Key[]) new Comparable[maxN+1];	
-	}
-	
-	public boolean isEmpty() { return N == 0; }
-	public int size() { return N; }
-	
-	public void insert(Key v) {
-		pq[++N] = v;
-		swim(N);
-	}
-	
-	public Key delMax() {
-		Key max = pq[1];
-		exch(1, N--);
-		pq[N+1] = null;
-		sink(1);
-		return max;	
-	}
-}
-\end{lstlisting}
+\lstinputlisting{code/MaxPQ.java}
 
-Heap operations are illustrated in figure \ref{fig:heap-ops}.
+Heap operations are illustrated in \figuref{heap-ops}.
 
 \begin{figure}[ht]
 	\centering
 	\includegraphics[scale=0.55]{img/heap-ops.png}
 	\caption{Heap operations.}
 	\label{fig:heap-ops}
-\end{figure} 
+\end{figure}
 
-\begin{myprop}
-In a $N$-key priority queue, the heap algorithms
-require no more than $1 + \log N$ compares for
-insert and no more than $2\log N$ compares
-for remove the maximum.
-\end{myprop}
+\begin{mypropo}
+In an $N$-item priority queue, the heap algorithms
+require no more than $1 + \lg N$ compares for
+\emph{insert} and no more than $2\lg N$ compares
+for \emph{remove the maximum}.
+\end{mypropo}
 
 \end{document}

--- a/src/q5/algo-SINF1121/summary/algo-SINF1121-summary.tex
+++ b/src/q5/algo-SINF1121/summary/algo-SINF1121-summary.tex
@@ -7,7 +7,7 @@
 \usepackage{float}
 \usepackage{multirow}
 \usepackage{subcaption}
-\lstset{language=Java}
+\lstset{language=Java, basicstyle=\rm\small\ttfamily, tabsize=8}}
 
 \hypertitle[']{Algorithmics and data structures}{5}{SINF}{1121}
 {Charles Momin\and Antoine Paris\and Gilles Peiffer\and Sylvain Ramelot}
@@ -49,7 +49,7 @@ collection (which wouldn't be the case using arrays for example).
 \subsection{Stack}
 The working principle of a stack is illustrated in \figuref{stack}.
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=1.0]{img/stack.png}
 	\caption{Illustration of the working principle of a LIFO stack.}
@@ -61,7 +61,7 @@ The working principle of a stack is illustrated in \figuref{stack}.
 \subsection{Queue}
 The working principle of a queue is illustrated in \figuref{queue}.
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=1.0]{img/queue.png}
 	\caption{Illustration of the working principle of a FIFO queue.}
@@ -77,7 +77,7 @@ A bag is simply a stack without a \lstinline{pop()} subroutine.
 The aim of the game here is to sort arrays of items each containing a key
 according to a particular order (usually alphabetical or numerical). The notion
 of a key is included in a mechanism own to \java{}, the \lstinline{Comparable}
-interface (with for example the \lstinline{compareTo} subroutine).
+interface (with for example the \lstinline{compareTo} method).
 
 Two types of sorting algorithms exist:
 \begin{itemize}
@@ -122,7 +122,7 @@ There are always $\frac{N^2}{2}$ comparisons and $N$ swaps.
 This algorithm is the one generally used to sort playing cards. Every card
 is placed where it belongs between already sorted cards. The only difference is
 that in this algorithm, there has to be a certain amount of available memory
-space to insert the item, and therefor all following items have to be moved one
+space to insert the item, and therefore all following items have to be moved one
 step to the right.
 
 \subsubsection{Implementation}
@@ -152,7 +152,7 @@ An array is $h$-sorted when all elements separated by $h$ positions are sorted.
 Concretely, the algorithm is implemented by using insertion sort to obtain
 successive $h$-sorted arrays, with $h$ decreasing.
 
-\lstinputlisting{code/Shell.java}
+\lstinputlisting[tabsize=6]{code/Shell.java}
 
 \subsubsection{Properties}
 \begin{myprop}
@@ -178,7 +178,7 @@ comparison sorts are $\bigomega(n \log n)$).
 The two possible implementations of merge sort use the following
 \lstinline{merge} subroutine:
 
-\lstinputlisting{code/MergeMethod.java}
+\lstinputlisting{code/mergeMethod.java}
 
 \subsubsection{Top-down merge sort}
 The list is split into sublists and each sublist is sorted recursively then
@@ -186,7 +186,7 @@ merged.
 
 \lstinputlisting{code/Merge.java}
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.5]{img/mergesortTD.png}
 	\caption{Trace of merge results for top-down merge sort.}
@@ -198,7 +198,7 @@ form bigger ones.
 
 \lstinputlisting{code/MergeBU.java}
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.5]{img/mergesortBU.png}
 	\caption{Trace of merge results for bottom-up merge sort.}
@@ -218,7 +218,7 @@ Quicksort is a \textit{divide and conquer} algorithm. It first divides a large
 array into two smaller sub-arrays. It can then recursively sort the sub-arrays
 as in \figuref{quicksort-overview}.
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.7]{img/quicksort-overview.png}
 	\caption{Quicksort overview.}
@@ -239,7 +239,7 @@ three conditions are met:
 
 These 3 conditions are summarised in \figuref{part-overview}.
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.7]{img/partitioning-overview.png}
 	\caption{Partitioning overview.}
@@ -251,7 +251,7 @@ The trace of the following code is found in \figuref{part-trace}
 
 \lstinputlisting{code/Quick.java}
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.5]{img/partitioning.png}
 	\caption{Partitioning trace.}
@@ -274,7 +274,7 @@ modifying the quicksort algorithm slightly.
 This can be achieved by using 3 partitions instead of 2, as shown in
 \figuref{part3-overview}.
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.7]{img/partitioning3-overview.png}
 	\caption{3-way partitioning overview.}
@@ -293,14 +293,14 @@ The trace of the following code is found in \figuref{part3-trace}
 
 \lstinputlisting{code/Quick3way.java}
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.7]{img/partitioning3.png}
 	\caption{3-way partitioning trace.}
 	\label{fig:part3-trace}
 \end{figure}
 
-\begin{table}
+\begin{table}[H]
 \centering
 \begin{tabular}{c|c|c|c|c}
 	\hline
@@ -339,7 +339,7 @@ indices and values are array entries.
 
 The API for a generic basic symbol table is given in \figuref{st-api}.
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.5]{img/symbol-table-api.png}
 	\caption{API for a generic basic symbol table.}
@@ -351,7 +351,7 @@ For applications where keys are \lstinline{Comparable}, we usually talk about
 
 The API for a generic ordered symbol table is given in \figuref{ost-api}.
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.5]{img/ordered-symbol-table-api.png}
 	\caption{API for a generic ordered symbol table.}
@@ -419,7 +419,7 @@ This restriction is illustrated in \figuref{bst-anatomy}.
 Note that on a binary tree that is not a binary \textit{search}
 tree, we don't have this restriction.
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.65]{img/bst-anatomy.png}
 	\caption{BST anatomy.}
@@ -492,7 +492,7 @@ Note that deletion in a BST is not commutative. Try for
 example to delete 4 and then 3 and 3 and then 4 in
 the tree given in \figuref{nc-deletion}.
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\begin{tikzpicture}
 		\node [circle,draw] {4}
@@ -557,7 +557,7 @@ of the tree on a line at the bottom of the tree :
 Applied on \figuref{bst-anatomy} :
 A C E H R S X.
 
-\paragraph{Postorder (\textit{postfixe} ou \textit{suffixe})}
+\paragraph{Postorder (\textit{postfixe} or \textit{suffixe})}
 Visit each node after having visited each child.
 \lstinputlisting{code/Postorder.java}
 Applied on \figuref{bst-anatomy} :
@@ -621,7 +621,7 @@ of an $N$-node 2-3 tree is between $\log_3 N$ (if the tree is
 all 3-nodes) and $\lg N$ (if the tree is all 2-nodes).
 \end{mypropo}
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\begin{subfigure}[t]{.5\textwidth}
 		\centering
@@ -639,14 +639,14 @@ all 3-nodes) and $\lg N$ (if the tree is all 2-nodes).
 	\label{fig:23tree-inserta}
 \end{figure}
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.55]{img/23tree-insert3b.png}
 	\caption{}
 	\label{fig:23tree-insertb}
 \end{figure}
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\begin{subfigure}[t]{.5\textwidth}
 		\centering
@@ -696,9 +696,9 @@ the following three restrictions:
 There is a 1-1 correspondence between red-black BSTs and 2-3 trees.
 \end{mypropo}
 
-Proposition \ref{correspondence} is illustrated in \figuref{redblack-1-1}.
+Proposition~\ref{correspondence} is illustrated in \figuref{redblack-1-1}.
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\begin{subfigure}[t]{.48\textwidth}
 		\centering
@@ -732,7 +732,7 @@ These two methods will help us to write other methods later. They
 are illustrated in \figuref{redblack-left-rotate} and
 \figuref{redblack-right-rotate}.
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\begin{subfigure}[t]{.5\textwidth}
 		\centering
@@ -759,7 +759,7 @@ split a 4-node.
 
 This method is illustrated in \figuref{color-flip}.
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.55]{img/color-flip.png}
 	\caption{Flipping colors to split a 4-node.}
@@ -772,9 +772,9 @@ implement insertion in red-black BSTs.
 \lstinputlisting{code/RedBlackPut.java}
 
 A summary of rotations and colors flipping involved in insert is
-given in figure \ref{fig:insert-summary}.
+given in \figuref{insert-summary}.
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.55]{img/insert-summary.png}
 	\caption{Operations involved in insert.}
@@ -914,7 +914,7 @@ Now that we know how to hash, we need a collision resolution
 process. The first collision resolution process is illustrated
 in \figuref{separate-chaining}.
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.6]{img/separate-chaining.png}
 	\caption{For each of the $M$ array indices, we build a
@@ -966,7 +966,7 @@ straightforward.
 We define $\alpha = N/M$ as the \textit{load factor}
 of a hash table. For separate chaining, $\alpha$ is
 the average number of keys per list and is often
-larger than 1. For open addressing, $\alpha$ is the
+larger than 1. For linear probing, $\alpha$ is the
 percentage of table entries that are occupied: it
 \emph{must} be less than 1.\footnote{If the load
 factor reaches 1, search misses would go into an
@@ -988,7 +988,7 @@ The cost-summary for symbol-tables implementations is given
 in \tabref{cost-summary-searching}.
 
 % auto-generated from here http://www.tablesgenerator.com/ #flemme
-\begin{table}[ht]
+\begin{table}[H]
 \centering
 \begin{tabular}{c|cccc|c}
 \multirow{2}{*}{\begin{tabular}[c]{@{}c@{}}algorithm \\(data
@@ -1040,7 +1040,7 @@ goals are the following ones:
 To achieve them, we have to adjust the symbol-table API (\figuref{triesAPI}) to
 provide specific character-based operations for string keys.
 
-\begin{figure}[ht!]
+\begin{figure}[H]
 \centering
 \includegraphics[width=.7\linewidth]{img/APItries.png}
 \caption{Tries API.}
@@ -1081,7 +1081,7 @@ representation is given in \figuref{basic_trie}.
 \end{mydef}
 
 
-\begin{figure}[ht!]
+\begin{figure}[H]
 \centering
 \includegraphics[width=.4\linewidth]{img/tries.png}
 \caption{Basic trie.}
@@ -1117,7 +1117,7 @@ result is also a \textbf{search miss}.}
 
 An example of search is given in \figuref{basic_trie_search}.
 
-\begin{figure}[ht!]
+\begin{figure}[H]
 \centering
 \includegraphics[width=.75\linewidth]{img/trieSe.png}
 \caption{Search in a basic trie.}
@@ -1142,7 +1142,7 @@ to the value corresponding to the key.}
 An example of insertion in a basic trie is given in
 \figuref{basic_trie_insertion}.
 
-\begin{figure}[ht!]
+\begin{figure}[H]
 \centering
 \includegraphics[width=.4\linewidth]{img/trieIn1.png}\hfill
 \includegraphics[width=.3\linewidth]{img/trieIn2.png}\hfill
@@ -1182,7 +1182,7 @@ substring with the obtained length. See code below:
 
 \lstinputlisting{code/LongestPrefixOf.java}
 
-\begin{figure}[ht!]
+\begin{figure}[H]
 \centering
 \includegraphics[width=.45\linewidth]{img/keysRe.png}
 \caption{Key recuperation.}
@@ -1204,7 +1204,7 @@ An example is given in \figuref{trieDel}. A possible implementation is
 given below:
 \lstinputlisting{code/TrieDelete.java}
 
-\begin{figure}[ht!]
+\begin{figure}[H]
 \centering
 \includegraphics[width=.75\linewidth]{img/trieDel.png}
 \caption{Deletion with basic trie.}
@@ -1264,7 +1264,7 @@ search key character. The algorithm is applied recursively.
 The insertion is like an insertion for tries: beginning with a search and then
 add the value in a new node or not. A example is given in \figuref{TSTSe}.
 
-\begin{figure}[ht!]
+\begin{figure}[H]
 \centering
 \includegraphics[width=.4\linewidth]{img/TST.png}
 \includegraphics[width=.4\linewidth]{img/TSTSe.png}
@@ -1278,7 +1278,7 @@ as keys the characters corresponding to non-null links.
 Continuing the correspondence, TSTs correspond to 3-way string quicksort
 (\figuref{TSTnode}).
 
-\begin{figure}[ht!]
+\begin{figure}[H]
 \centering
 \includegraphics[width=.75\linewidth]{img/TSTnode.png}
 \caption{Node representation of a TST.}
@@ -1348,7 +1348,7 @@ alphabets, where space may not be available for R-way tries, TSTs are
 preferable, since they use a logarithmic number of character compares, while
 BSTs use a logarithmic number of key compares.
 
-\begin{figure}[ht!]
+\begin{figure}[H]
 \centering
 \includegraphics[width=.75\linewidth]{img/perf.png}
 \label{perf}
@@ -1399,8 +1399,8 @@ We substract off the leading digit, multiply it by $R$, then add
 the trailing digit. Now, the crucial point is that we do not have
 to maintain the values of the numbers (i.e. $x_i$), just the
 values of their remainders when divided by $Q$ (i.e. $h(x_i)$).
-Remember the property of the modulus operation discussed in remark
-\ref{rem:mod-prop}.
+Remember the property of the modulus operation discussed
+in remark~\ref{rem:mod-prop}.
 
 \paragraph{Implementation}
 Here is the implementation of the \textit{Monte Carlo}
@@ -1764,6 +1764,15 @@ Prim's algorithm computes the MST of any connected edge-weighted graph.
 \end{figure}
 
 \begin{myrem}
+% Le gros problème de Kruskal par rapport à Prim
+% n'est pas tant cette augmentation de la complexité (elle est en $\alpha(n)$ donc bien négligeable),
+% mais sa grosse consommation en mémoire vu qu'il doit doit trier l'ensemble des arêtes du graphe.
+% C'est surtout un problème si le graphe est implicite,
+% et donc que les arêtes doivent être générés dynamiquement.
+% Prim peut être facilement optimisé pour ne pas avoir à retenir toutes les arêtes,
+% tandis que Kruskal a plus de chances de souffrir
+% car il faut que sa méthode de tri soit adaptée
+% (typiquement, faire une priority queue à taille fixée).
 Kruskal's algorithm is generally slower than Prim's algorithm because it has to
 do a \lstinline$connected()$ operation for each edge, in addition to the
 priority-queue operations that both algorithms do for each edge processed.
@@ -1800,7 +1809,7 @@ a number of disjoint subsets (equivalence classes).
 
 The API is given in \figuref{uf-api}.
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.6]{img/uf-api.png}
 	\caption{API of union-find data structure.}
@@ -1844,7 +1853,7 @@ each call to \lstinline|union()| that combines
 two components.
 \end{mypropo}
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.6]{img/quick-find-overview.png}
 	\caption{Quick-find overview.}
@@ -1871,7 +1880,7 @@ root.
 
 \lstinputlisting{code/Union.java}
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.55]{img/quick-union-overview.png}
 	\caption{Quick-union overview.}
@@ -1923,7 +1932,7 @@ $\lg N$.
 
 \subsubsection{Summary}
 
-\begin{table}[ht]
+\begin{table}[H]
 	\centering
 	\begin{tabular}{c|ccc}
 		\textbf{Algorithm} & \textbf{Constructor} & \textbf{Union} & \textbf{Find} \\
@@ -1943,7 +1952,7 @@ consider a \lstinline|MaxPQ|. \lstinline|MinPQ| is easily
 obtained from \lstinline|MaxPQ| (you only need to use
 min-heap instead of a max-heap in what follows).
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.55]{img/pq-api.png}
 	\caption{API of a priority queue.}
@@ -1981,7 +1990,7 @@ are as far left as possible.
 
 A heap-ordered complete binary tree is illustrated in \figuref{heap}.
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.55]{img/heap.png}
 	\caption{A heap-ordered complete binary tree.}
@@ -2036,7 +2045,7 @@ or the bottom) as can be seen in \figuref{sink}.
 
 \lstinputlisting{code/Sink.java}
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\begin{subfigure}{.5\textwidth}
 		\centering
@@ -2062,7 +2071,7 @@ is quite straightforward.
 
 Heap operations are illustrated in \figuref{heap-ops}.
 
-\begin{figure}[ht]
+\begin{figure}[H]
 	\centering
 	\includegraphics[scale=0.55]{img/heap-ops.png}
 	\caption{Heap operations.}

--- a/src/q5/algo-SINF1121/summary/algo-SINF1121-summary.tex
+++ b/src/q5/algo-SINF1121/summary/algo-SINF1121-summary.tex
@@ -7,7 +7,7 @@
 \usepackage{float}
 \usepackage{multirow}
 \usepackage{subcaption}
-\lstset{language=Java, basicstyle=\rm\small\ttfamily, tabsize=2}
+\lstset{language=Java}
 
 \hypertitle[']{Algorithmics and data structures}{5}{SINF}{1121}
 {Charles Momin\and Antoine Paris\and Gilles Peiffer\and Sylvain Ramelot}

--- a/src/q5/algo-SINF1121/summary/algo-SINF1121-summary.tex
+++ b/src/q5/algo-SINF1121/summary/algo-SINF1121-summary.tex
@@ -300,6 +300,8 @@ The trace of the following code is found in \figuref{part3-trace}
 	\label{fig:part3-trace}
 \end{figure}
 
+% TODO : see if this is correct
+% (namely, which symbol to use, see PR #528 on GitHub)
 \begin{table}[H]
 \centering
 \begin{tabular}{c|c|c|c|c}

--- a/src/q5/algo-SINF1121/summary/algo-SINF1121-summary.tex
+++ b/src/q5/algo-SINF1121/summary/algo-SINF1121-summary.tex
@@ -7,7 +7,7 @@
 \usepackage{float}
 \usepackage{multirow}
 \usepackage{subcaption}
-\lstset{language=Java, basicstyle=\rm\small\ttfamily, tabsize=8}}
+\lstset{language=Java, basicstyle=\rm\small\ttfamily, tabsize=8}
 
 \hypertitle[']{Algorithmics and data structures}{5}{SINF}{1121}
 {Charles Momin\and Antoine Paris\and Gilles Peiffer\and Sylvain Ramelot}

--- a/src/q5/algo-SINF1121/summary/algo-SINF1121-summary.tex
+++ b/src/q5/algo-SINF1121/summary/algo-SINF1121-summary.tex
@@ -931,7 +931,7 @@ Implementation of separate chaining is very easy
 (\lstinline|SequentialSearchST| is the implementation
 of the sequential search in an unordered linked list).
 
-\lstinputlisting{code/SeparateChaining.java}
+\lstinputlisting[tabsize=6]{code/SeparateChaining.java}
 
 \paragraph{Analysis}
 \begin{mypropo}

--- a/src/q5/algo-SINF1121/summary/code/BSTClass.java
+++ b/src/q5/algo-SINF1121/summary/code/BSTClass.java
@@ -1,3 +1,2 @@
-public class BST<Key extends Comparable<Key>, Value>
-{
+public class BST<Key extends Comparable<Key>, Value> {
 	private Node root;

--- a/src/q5/algo-SINF1121/summary/code/BSTClass.java
+++ b/src/q5/algo-SINF1121/summary/code/BSTClass.java
@@ -1,0 +1,3 @@
+public class BST<Key extends Comparable<Key>, Value>
+{
+	private Node root;

--- a/src/q5/algo-SINF1121/summary/code/BinarySearchST.java
+++ b/src/q5/algo-SINF1121/summary/code/BinarySearchST.java
@@ -1,0 +1,8 @@
+public BinarySearchST(int capacity) {
+    keys = (Key[]) new Comparable[capacity];
+    vals = (Value[]) new Object[capacity];
+}
+
+public int size() {
+    return N;
+}

--- a/src/q5/algo-SINF1121/summary/code/BinarySearchST.java
+++ b/src/q5/algo-SINF1121/summary/code/BinarySearchST.java
@@ -1,8 +1,8 @@
 public BinarySearchST(int capacity) {
-    keys = (Key[]) new Comparable[capacity];
-    vals = (Value[]) new Object[capacity];
+	keys = (Key[]) new Comparable[capacity];
+	vals = (Value[]) new Object[capacity];
 }
 
 public int size() {
-    return N;
+	return N;
 }

--- a/src/q5/algo-SINF1121/summary/code/BinarySearchSTClass.java
+++ b/src/q5/algo-SINF1121/summary/code/BinarySearchSTClass.java
@@ -1,2 +1,1 @@
-public class BinarySearchST<Key extends Comparable<Key>, Value>
-{
+public class BinarySearchST<Key extends Comparable<Key>, Value> {

--- a/src/q5/algo-SINF1121/summary/code/BinarySearchSTClass.java
+++ b/src/q5/algo-SINF1121/summary/code/BinarySearchSTClass.java
@@ -1,0 +1,2 @@
+public class BinarySearchST<Key extends Comparable<Key>, Value>
+{

--- a/src/q5/algo-SINF1121/summary/code/DFSOrder.java
+++ b/src/q5/algo-SINF1121/summary/code/DFSOrder.java
@@ -1,37 +1,40 @@
 public class DepthFirstOrder {
-    private boolean[] marked;
-    private Queue<Integer> pre; // vertices in preorder
-    private Queue<Integer> post; // vertices in postorder
-    private Stack<Integer> reversePost; // vertices in reverse postorder
+	private boolean[] marked;
+	private Queue<Integer> pre; // vertices in preorder
+	private Queue<Integer> post; // vertices in postorder
+	private Stack<Integer> reversePost; // vertices in reverse postorder
 
-    public DepthFirstOrder(Digraph G) {
-        pre = new Queue<Integer>();
-        post = new Queue<Integer>();
-        reversePost = new Stack<Integer>();
-        marked = new boolean[G.V()];
-        for (int v = 0; v < G.V(); v++)
-            if (!marked[v]) dfs(G, v);
-    }
+	public DepthFirstOrder(Digraph G) {
+		pre = new Queue<Integer>();
+		post = new Queue<Integer>();
+		reversePost = new Stack<Integer>();
+		marked = new boolean[G.V()];
+		for (int v = 0; v < G.V(); v++) {
+			if (!marked[v])
+				dfs(G, v);
+		}
+	}
 
-    private void dfs(Digraph G, int v) {
-        pre.enqueue(v);
-        marked[v] = true;
-        for (int w : G.adj(v))
-            if (!marked[w])
-                dfs(G, w);
-        post.enqueue(v);
-        reversePost.push(v);
-    }
+	private void dfs(Digraph G, int v) {
+		pre.enqueue(v);
+		marked[v] = true;
+		for (int w : G.adj(v)) {
+			if (!marked[w])
+				dfs(G, w);
+		}
+		post.enqueue(v);
+		reversePost.push(v);
+	}
 
-    public Iterable<Integer> pre() {
-        return pre;
-    }
+	public Iterable<Integer> pre() {
+		return pre;
+	}
 
-    public Iterable<Integer> post() {
-        return post;
-    }
+	public Iterable<Integer> post() {
+		return post;
+	}
 
-    public Iterable<Integer> reversePost() {
-        return reversePost;
-    }
+	public Iterable<Integer> reversePost() {
+		return reversePost;
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/DepthFirstPath.java
+++ b/src/q5/algo-SINF1121/summary/code/DepthFirstPath.java
@@ -1,34 +1,36 @@
 public class DepthFirstPaths {
-    private boolean[] marked; // Has dfs() been called for this vertex?
-    private int[] edgeTo; // last vertex on known path to this vertex
-    private final int s; // source
+	private boolean[] marked; // Has dfs() been called for this vertex?
+	private int[] edgeTo; // last vertex on known path to this vertex
+	private final int s; // source
 
-    public DepthFirstPaths(Graph G, int s) {
-        marked = new boolean[G.V()];
-        edgeTo = new int[G.V()];
-        this.s = s;
-        dfs(G, s);
-    }
+	public DepthFirstPaths(Graph G, int s) {
+		marked = new boolean[G.V()];
+		edgeTo = new int[G.V()];
+		this.s = s;
+		dfs(G, s);
+	}
 
-    private void dfs(Graph G, int v) {
-        marked[v] = true;
-        for (int w : G.adj(v))
-            if (!marked[w]) {
-                edgeTo[w] = v;
-                dfs(G, w);
-            }
-    }
+	private void dfs(Graph G, int v) {
+		marked[v] = true;
+		for (int w : G.adj(v)) {
+			if (!marked[w]) {
+				edgeTo[w] = v;
+				dfs(G, w);
+			}
+		}
+	}
 
-    public boolean hasPathTo(int v) {
-        return marked[v];
-    }
+	public boolean hasPathTo(int v) {
+		return marked[v];
+	}
 
-    public Iterable<Integer> pathTo(int v) {
-        if (!hasPathTo(v)) return null;
-        Stack<Integer> path = new Stack<Integer>();
-        for (int x = v; x != s; x = edgeTo[x])
-            path.push(x);
-        path.push(s);
-        return path;
-    }
+	public Iterable<Integer> pathTo(int v) {
+		if (!hasPathTo(v))
+			return null;
+		Stack<Integer> path = new Stack<Integer>();
+		for (int x = v; x != s; x = edgeTo[x])
+			path.push(x);
+		path.push(s);
+		return path;
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/DepthFirstSearch.java
+++ b/src/q5/algo-SINF1121/summary/code/DepthFirstSearch.java
@@ -1,24 +1,26 @@
 public class DepthFirstSearch {
-    private boolean[] marked;
-    private int count;
+	private boolean[] marked;
+	private int count;
 
-    public DepthFirstSearch(Graph G, int s) {
-        marked = new boolean[G.V()];
-        dfs(G, s);
-    }
+	public DepthFirstSearch(Graph G, int s) {
+		marked = new boolean[G.V()];
+		dfs(G, s);
+	}
 
-    private void dfs(Graph G, int v) {
-        marked[v] = true;
-        count++;
-        for (int w : G.adj(v))
-            if (!marked[w]) dfs(G, w);
-    }
+	private void dfs(Graph G, int v) {
+		marked[v] = true;
+		count++;
+		for (int w : G.adj(v)) {
+			if (!marked[w])
+				dfs(G, w);
+		}
+	}
 
-    public boolean marked(int w) {
-        return marked[w];
-    }
+	public boolean marked(int w) {
+		return marked[w];
+	}
 
-    public int count() {
-        return count;
-    }
+	public int count() {
+		return count;
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/Dijkstra.java
+++ b/src/q5/algo-SINF1121/summary/code/Dijkstra.java
@@ -1,35 +1,37 @@
 public class DijkstraSP {
-    private DirectedEdge[] edgeTo;
-    private double[] distTo;
-    private IndexMinPQ<Double> pq;
+	private DirectedEdge[] edgeTo;
+	private double[] distTo;
+	private IndexMinPQ<Double> pq;
 
-    public DijkstraSP(EdgeWeightedDigraph G, int s) {
-        edgeTo = new DirectedEdge[G.V()];
-        distTo = new double[G.V()];
-        pq = new IndexMinPQ<Double>(G.V());
-        for (int v = 0; v < G.V(); v++)
-            distTo[v] = Double.POSITIVE_INFINITY;
-        distTo[s] = 0.0;
-        pq.insert(s, 0.0);
-        while (!pq.isEmpty())
-            relax(G, pq.delMin())
-    }
+	public DijkstraSP(EdgeWeightedDigraph G, int s) {
+		edgeTo = new DirectedEdge[G.V()];
+		distTo = new double[G.V()];
+		pq = new IndexMinPQ<Double>(G.V());
+		for (int v = 0; v < G.V(); v++)
+			distTo[v] = Double.POSITIVE_INFINITY;
+		distTo[s] = 0.0;
+		pq.insert(s, 0.0);
+		while (!pq.isEmpty())
+			relax(G, pq.delMin())
+	}
 
-    private void relax(EdgeWeightedDigraph G, int v) {
-        for (DirectedEdge e : G.adj(v)) {
-            int w = e.to();
-            if (distTo[w] > distTo[v] + e.weight()) {
-                distTo[w] = distTo[v] + e.weight();
-                edgeTo[w] = e;
-                if (pq.contains(w)) pq.change(w, distTo[w]);
-                else pq.insert(w, distTo[w]);
-            }
-        }
-    }
+	private void relax(EdgeWeightedDigraph G, int v) {
+		for (DirectedEdge e : G.adj(v)) {
+			int w = e.to();
+			if (distTo[w] > distTo[v] + e.weight()) {
+				distTo[w] = distTo[v] + e.weight();
+				edgeTo[w] = e;
+				if (pq.contains(w))
+					pq.change(w, distTo[w]);
+				else
+					pq.insert(w, distTo[w]);
+			}
+		}
+	}
 
-    public double distTo(int v) // standard client query methods
+	public double distTo(int v) // standard client query methods
 
-    public boolean hasPathTo(int v) // for SPT implementatations
+	public boolean hasPathTo(int v) // for SPT implementatations
 
-    public Iterable<Edge> pathTo(int v) // (See page 649.)
+	public Iterable<Edge> pathTo(int v) // (See page 649.)
 }

--- a/src/q5/algo-SINF1121/summary/code/DirectedCycle.java
+++ b/src/q5/algo-SINF1121/summary/code/DirectedCycle.java
@@ -1,40 +1,44 @@
 public class DirectedCycle {
-    private boolean[] marked;
-    private int[] edgeTo;
-    private Stack<Integer> cycle; // vertices on a cycle (if one exists)
-    private boolean[] onStack; // vertices on recursive call stack
+	private boolean[] marked;
+	private int[] edgeTo;
+	private Stack<Integer> cycle; // vertices on a cycle (if one exists)
+	private boolean[] onStack; // vertices on recursive call stack
 
-    public DirectedCycle(Digraph G) {
-        onStack = new boolean[G.V()];
-        edgeTo = new int[G.V()];
-        marked = new boolean[G.V()];
-        for (int v = 0; v < G.V(); v++)
-            if (!marked[v]) dfs(G, v);
-    }
+	public DirectedCycle(Digraph G) {
+		onStack = new boolean[G.V()];
+		edgeTo = new int[G.V()];
+		marked = new boolean[G.V()];
+		for (int v = 0; v < G.V(); v++) {
+			if (!marked[v])
+				dfs(G, v);
+		}
+	}
 
-    private void dfs(Digraph G, int v) {
-        onStack[v] = true;
-        marked[v] = true;
-        for (int w : G.adj(v))
-            if (this.hasCycle()) return;
-            else if (!marked[w]) {
-                edgeTo[w] = v;
-                dfs(G, w);
-            } else if (onStack[w]) {
-                cycle = new Stack<Integer>();
-                for (int x = v; x != w; x = edgeTo[x])
-                    cycle.push(x);
-                cycle.push(w);
-                cycle.push(v);
-            }
-        onStack[v] = false;
-    }
+	private void dfs(Digraph G, int v) {
+		onStack[v] = true;
+		marked[v] = true;
+		for (int w : G.adj(v)) {
+			if (this.hasCycle()) {
+				return;
+			} else if (!marked[w]) {
+				edgeTo[w] = v;
+				dfs(G, w);
+			} else if (onStack[w]) {
+				cycle = new Stack<Integer>();
+				for (int x = v; x != w; x = edgeTo[x])
+					cycle.push(x);
+				cycle.push(w);
+				cycle.push(v);
+			}
+		}
+		onStack[v] = false;
+	}
 
-    public boolean hasCycle() {
-        return cycle != null;
-    }
+	public boolean hasCycle() {
+		return cycle != null;
+	}
 
-    public Iterable<Integer> cycle() {
-        return cycle;
-    }
+	public Iterable<Integer> cycle() {
+		return cycle;
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/DirectedDFS.java
+++ b/src/q5/algo-SINF1121/summary/code/DirectedDFS.java
@@ -1,35 +1,41 @@
 public class DirectedDFS {
-    private boolean[] marked;
+	private boolean[] marked;
 
-    public DirectedDFS(Digraph G, int s) { //find vertices in G that are reachable from s
-        marked = new boolean[G.V()];
-        dfs(G, s);
-    }
+	public DirectedDFS(Digraph G, int s) { //find vertices in G that are reachable from s
+		marked = new boolean[G.V()];
+		dfs(G, s);
+	}
 
-    public DirectedDFS(Digraph G, Iterable<Integer> sources) {//find vertices in G that are reachable from sources
-        marked = new boolean[G.V()];
-        for (int s : sources)
-            if (!marked[s]) dfs(G, s);
-    }
+	public DirectedDFS(Digraph G, Iterable<Integer> sources) {//find vertices in G that are reachable from sources
+		marked = new boolean[G.V()];
+		for (int s : sources) {
+			if (!marked[s])
+				dfs(G, s);
+		}
+	}
 
-    private void dfs(Digraph G, int v) {
-        marked[v] = true;
-        for (int w : G.adj(v))
-            if (!marked[w]) dfs(G, w);
-    }
+	private void dfs(Digraph G, int v) {
+		marked[v] = true;
+		for (int w : G.adj(v)) {
+			if (!marked[w])
+				dfs(G, w);
+		}
+	}
 
-    public boolean marked(int v) {
-        return marked[v];
-    }
+	public boolean marked(int v) {
+		return marked[v];
+	}
 
-    public static void main(String[] args) {
-        Digraph G = new Digraph(new In(args[0]));
-        Bag<Integer> sources = new Bag<Integer>();
-        for (int i = 1; i < args.length; i++)
-            sources.add(Integer.parseInt(args[i]));
-        DirectedDFS reachable = new DirectedDFS(G, sources);
-        for (int v = 0; v < G.V(); v++)
-            if (reachable.marked(v)) StdOut.print(v + " ");
-        StdOut.println();
-    }
+	public static void main(String[] args) {
+		Digraph G = new Digraph(new In(args[0]));
+		Bag<Integer> sources = new Bag<Integer>();
+		for (int i = 1; i < args.length; i++)
+			sources.add(Integer.parseInt(args[i]));
+		DirectedDFS reachable = new DirectedDFS(G, sources);
+		for (int v = 0; v < G.V(); v++) {
+			if (reachable.marked(v))
+				StdOut.print(v + " ");
+		}
+		StdOut.println();
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/Find.java
+++ b/src/q5/algo-SINF1121/summary/code/Find.java
@@ -1,0 +1,4 @@
+public int find(int p) {
+	while (p != id[p]) p = id[p];
+	return p;
+}

--- a/src/q5/algo-SINF1121/summary/code/Find.java
+++ b/src/q5/algo-SINF1121/summary/code/Find.java
@@ -1,4 +1,5 @@
 public int find(int p) {
-	while (p != id[p]) p = id[p];
+	while (p != id[p])
+		p = id[p];
 	return p;
 }

--- a/src/q5/algo-SINF1121/summary/code/FlipColors.java
+++ b/src/q5/algo-SINF1121/summary/code/FlipColors.java
@@ -1,0 +1,5 @@
+private void flipColors(Node h) {
+     h.color = RED;
+     h.left.color = BLACK;
+     h.right.color = BLACK;
+}

--- a/src/q5/algo-SINF1121/summary/code/FlipColors.java
+++ b/src/q5/algo-SINF1121/summary/code/FlipColors.java
@@ -1,5 +1,5 @@
 private void flipColors(Node h) {
-     h.color = RED;
-     h.left.color = BLACK;
-     h.right.color = BLACK;
+	h.color = RED;
+	h.left.color = BLACK;
+	h.right.color = BLACK;
 }

--- a/src/q5/algo-SINF1121/summary/code/Get.java
+++ b/src/q5/algo-SINF1121/summary/code/Get.java
@@ -1,6 +1,8 @@
 public Value get(Key key) {
-     if (isEmpty()) return null;
-     int i = rank(key);
-     if (i < N && keys[i].compareTo(key) == 0) return vals[i];
-     return null;
+	if (isEmpty())
+		return null;
+	int i = rank(key);
+	if (i < N && keys[i].compareTo(key) == 0)
+		return vals[i];
+	return null;
 }

--- a/src/q5/algo-SINF1121/summary/code/Get.java
+++ b/src/q5/algo-SINF1121/summary/code/Get.java
@@ -1,0 +1,6 @@
+public Value get(Key key) {
+     if (isEmpty()) return null;
+     int i = rank(key);
+     if (i < N && keys[i].compareTo(key) == 0) return vals[i];
+     return null;
+}

--- a/src/q5/algo-SINF1121/summary/code/Hash.java
+++ b/src/q5/algo-SINF1121/summary/code/Hash.java
@@ -1,0 +1,3 @@
+private int hash(Key x) {
+	return (x.hashCode() & 0x7fffffff) % M);   //be careful! "&" means bitwise AND
+}

--- a/src/q5/algo-SINF1121/summary/code/HibbardDeletion.java
+++ b/src/q5/algo-SINF1121/summary/code/HibbardDeletion.java
@@ -1,0 +1,23 @@
+public void delete(Key key) {
+     root = delete(root, key);
+}
+
+private Node delete(Node x, Key key) {
+     if (x == null) return null;
+     int cmp = key.compareTo(x.key);
+     if      (cmp < 0) x.left = delete(x.left, key);
+     else if (cmp > 0) x.right = delete(x.right, key);
+     else {
+          if(x.right == null) return x.left;
+          if(x.left == null) return x.right;
+          /* Choose successor to replace x (Hibbard)
+          if the node to delete has two children */
+          Node t = x;
+          x = min(t.right);
+          x.right = deleteMin(t.right);
+          x.left = t.left;
+     }
+
+     x.N = size(x.left) + size(x.right) +1;
+     return x;
+}

--- a/src/q5/algo-SINF1121/summary/code/HibbardDeletion.java
+++ b/src/q5/algo-SINF1121/summary/code/HibbardDeletion.java
@@ -1,23 +1,27 @@
 public void delete(Key key) {
-     root = delete(root, key);
+	root = delete(root, key);
 }
 
 private Node delete(Node x, Key key) {
-     if (x == null) return null;
-     int cmp = key.compareTo(x.key);
-     if      (cmp < 0) x.left = delete(x.left, key);
-     else if (cmp > 0) x.right = delete(x.right, key);
-     else {
-          if(x.right == null) return x.left;
-          if(x.left == null) return x.right;
-          /* Choose successor to replace x (Hibbard)
-          if the node to delete has two children */
-          Node t = x;
-          x = min(t.right);
-          x.right = deleteMin(t.right);
-          x.left = t.left;
-     }
-
-     x.N = size(x.left) + size(x.right) +1;
-     return x;
+	if (x == null)
+		return null;
+	int cmp = key.compareTo(x.key);
+	if (cmp < 0) {
+		x.left = delete(x.left, key);
+	} else if (cmp > 0) {
+		x.right = delete(x.right, key);
+	} else {
+		if(x.right == null)
+			return x.left;
+		if(x.left == null)
+			return x.right;
+		/* Choose successor to replace x (Hibbard)
+		if the node to delete has two children */
+		Node t = x;
+		x = min(t.right);
+		x.right = deleteMin(t.right);
+		x.left = t.left;
+	}
+	x.N = size(x.left) + size(x.right) +1;
+	return x;
 }

--- a/src/q5/algo-SINF1121/summary/code/Horner.java
+++ b/src/q5/algo-SINF1121/summary/code/Horner.java
@@ -1,0 +1,3 @@
+int hash = 0;
+for(int i = 0; i < s.length(); i++)
+	hash = (R * hash + s.charAt(i)) % M;

--- a/src/q5/algo-SINF1121/summary/code/Horner.java
+++ b/src/q5/algo-SINF1121/summary/code/Horner.java
@@ -1,3 +1,3 @@
 int hash = 0;
-for(int i = 0; i < s.length(); i++)
+for (int i = 0; i < s.length(); i++)
 	hash = (R * hash + s.charAt(i)) % M;

--- a/src/q5/algo-SINF1121/summary/code/Inorder.java
+++ b/src/q5/algo-SINF1121/summary/code/Inorder.java
@@ -1,5 +1,5 @@
 public static void inOrder(Node h) {
-	if(t != null) {
+	if (t != null) {
 		inOrder(t.left);
 		visit(t);
 		inOrder(t.right);

--- a/src/q5/algo-SINF1121/summary/code/Inorder.java
+++ b/src/q5/algo-SINF1121/summary/code/Inorder.java
@@ -1,0 +1,7 @@
+public static void inOrder(Node h) {
+	if(t != null) {
+		inOrder(t.left);
+		visit(t);
+		inOrder(t.right);
+	}
+}

--- a/src/q5/algo-SINF1121/summary/code/Insertion.java
+++ b/src/q5/algo-SINF1121/summary/code/Insertion.java
@@ -1,10 +1,10 @@
 public class Insertion {
-    public static void sort(Comparable[] a) {
-        int N = a.length;
-        for (int i = 1; i < N; i++) {
-            for (int j = i; j > 0 && less(a[j], a[j-1]); j--) {
-                exch(a, j, j-1);
-            }
-        }
-    }
+	public static void sort(Comparable[] a) {
+		int N = a.length;
+		for (int i = 1; i < N; i++) {
+			for (int j = i; j > 0 && less(a[j], a[j-1]); j--) {
+				exch(a, j, j-1);
+			}
+		}
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/KeysThatMatch.java
+++ b/src/q5/algo-SINF1121/summary/code/KeysThatMatch.java
@@ -1,18 +1,20 @@
-public Iterable<String> keysThatMatch(String pat)
-{
+public Iterable<String> keysThatMatch(String pat) {
 	Queue<String> q = new Queue<String>();
 	collect(root, "", pat, q);
 	return q;
 }
 
-public void collect(Node x, String pre, String pat, Queue<String> q)
-{
+public void collect(Node x, String pre, String pat, Queue<String> q) {
 	int d = pre.length();
-	if (x == null) return;
-	if (d == pat.length() && x.val != null) q.enqueue(pre);
-	if (d == pat.length()) return;
+	if (x == null)
+		return;
+	if (d == pat.length() && x.val != null)
+		q.enqueue(pre);
+	if (d == pat.length())
+		return;
 	char next = pat.charAt(d);
-	for (char c = 0; c < R; c++)
+	for (char c = 0; c < R; c++) {
 		if (next == '.' || next == c)
 			collect(x.next[c], pre + c, pat, q);
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/KeysThatMatch.java
+++ b/src/q5/algo-SINF1121/summary/code/KeysThatMatch.java
@@ -1,0 +1,18 @@
+public Iterable<String> keysThatMatch(String pat)
+{
+	Queue<String> q = new Queue<String>();
+	collect(root, "", pat, q);
+	return q;
+}
+
+public void collect(Node x, String pre, String pat, Queue<String> q)
+{
+	int d = pre.length();
+	if (x == null) return;
+	if (d == pat.length() && x.val != null) q.enqueue(pre);
+	if (d == pat.length()) return;
+	char next = pat.charAt(d);
+	for (char c = 0; c < R; c++)
+		if (next == '.' || next == c)
+			collect(x.next[c], pre + c, pat, q);
+}

--- a/src/q5/algo-SINF1121/summary/code/KeysWithPrefix.java
+++ b/src/q5/algo-SINF1121/summary/code/KeysWithPrefix.java
@@ -1,0 +1,17 @@
+public Iterable<String> keys()
+{ return keysWithPrefix(""); }
+
+public Iterable<String> keysWithPrefix(String pre)
+{
+	Queue<String> q = new Queue<String>();
+	collect(get(root, pre, 0), pre, q);
+	return q;
+}
+
+private void collect(Node x, String pre, Queue<String> q)
+{
+	if (x == null) return;
+	if (x.val != null) q.enqueue(pre);
+	for (char c = 0; c < R; c++)
+		collect(x.next[c], pre + c, q);
+}

--- a/src/q5/algo-SINF1121/summary/code/KeysWithPrefix.java
+++ b/src/q5/algo-SINF1121/summary/code/KeysWithPrefix.java
@@ -1,17 +1,18 @@
-public Iterable<String> keys()
-{ return keysWithPrefix(""); }
+public Iterable<String> keys() {
+	return keysWithPrefix("");
+}
 
-public Iterable<String> keysWithPrefix(String pre)
-{
+public Iterable<String> keysWithPrefix(String pre) {
 	Queue<String> q = new Queue<String>();
 	collect(get(root, pre, 0), pre, q);
 	return q;
 }
 
-private void collect(Node x, String pre, Queue<String> q)
-{
-	if (x == null) return;
-	if (x.val != null) q.enqueue(pre);
+private void collect(Node x, String pre, Queue<String> q) {
+	if (x == null)
+		return;
+	if (x.val != null)
+		q.enqueue(pre);
 	for (char c = 0; c < R; c++)
 		collect(x.next[c], pre + c, q);
 }

--- a/src/q5/algo-SINF1121/summary/code/Kruskal2.java
+++ b/src/q5/algo-SINF1121/summary/code/Kruskal2.java
@@ -1,22 +1,23 @@
 public class KruskalMST {
-    private Queue<Edge> mst;
+	private Queue<Edge> mst;
 
-    public KruskalMST(EdgeWeightedGraph G) {
-        mst = new Queue<Edge>();
-        MinPQ<Edge> pq = new MinPQ<Edge>(G.edges());
-        UF uf = new UF(G.V());
-        while (!pq.isEmpty() && mst.size() < G.V() - 1) {
-            Edge e = pq.delMin(); // Get min weight edge on pq
-            int v = e.either(), w = e.other(v); // and its vertices.
-            if (uf.connected(v, w)) continue; // Ignore ineligible edges.
-            uf.union(v, w); // Merge components.
-            mst.enqueue(e); // Add edge to mst.
-        }
-    }
+	public KruskalMST(EdgeWeightedGraph G) {
+		mst = new Queue<Edge>();
+		MinPQ<Edge> pq = new MinPQ<Edge>(G.edges());
+		UF uf = new UF(G.V());
+		while (!pq.isEmpty() && mst.size() < G.V() - 1) {
+			Edge e = pq.delMin(); // Get min weight edge on pq
+			int v = e.either(), w = e.other(v); // and its vertices.
+			if (uf.connected(v, w))
+				continue; // Ignore ineligible edges.
+			uf.union(v, w); // Merge components.
+			mst.enqueue(e); // Add edge to mst.
+		}
+	}
 
-    public Iterable<Edge> edges() {
-        return mst;
-    }
-
-    public double weight() // See Exercise 4.3.31.
+	public Iterable<Edge> edges() {
+		return mst;
+	}
+	
+	public double weight() // See Exercise 4.3.31.
 }

--- a/src/q5/algo-SINF1121/summary/code/LazyPrimMST.java
+++ b/src/q5/algo-SINF1121/summary/code/LazyPrimMST.java
@@ -1,32 +1,37 @@
 public class LazyPrimMST {
-    private boolean[] marked; // MST vertices
-    private Queue<Edge> mst; // MST edges
-    private MinPQ<Edge> pq; // crossing (and ineligible) edges
+	private boolean[] marked; // MST vertices
+	private Queue<Edge> mst; // MST edges
+	private MinPQ<Edge> pq; // crossing (and ineligible) edges
 
-    public LazyPrimMST(EdgeWeightedGraph G) {
-        pq = new MinPQ<Edge>();
-        marked = new boolean[G.V()];
-        mst = new Queue<Edge>();
-        visit(G, 0); // assumes G is connected (see Exercise 4.3.22)
-        while (!pq.isEmpty()) {
-            Edge e = pq.delMin(); // Get lowest-weight
-            int v = e.either(), w = e.other(v); // edge from pq.
-            if (marked[v] && marked[w]) continue; // Skip if ineligible.
-            mst.enqueue(e); // Add edge to tree.
-            if (!marked[v]) visit(G, v); // Add vertex to tree
-            if (!marked[w]) visit(G, w); // (either v or w).
-        }
-    }
+	public LazyPrimMST(EdgeWeightedGraph G) {
+		pq = new MinPQ<Edge>();
+		marked = new boolean[G.V()];
+		mst = new Queue<Edge>();
+		visit(G, 0); // assumes G is connected (see Exercise 4.3.22)
+		while (!pq.isEmpty()) {
+			Edge e = pq.delMin(); // Get lowest-weight
+			int v = e.either(), w = e.other(v); // edge from pq.
+			if (marked[v] && marked[w])
+				continue; // Skip if ineligible.
+			mst.enqueue(e); // Add edge to tree.
+			if (!marked[v])
+				visit(G, v); // Add vertex to tree
+			if (!marked[w])
+				visit(G, w); // (either v or w).
+		}
+	}
 
-    private void visit(EdgeWeightedGraph G, int v) { // Mark v and add to pq all edges from v to unmarked vertices.
-        marked[v] = true;
-        for (Edge e : G.adj(v))
-            if (!marked[e.other(v)]) pq.insert(e);
-    }
+	private void visit(EdgeWeightedGraph G, int v) { // Mark v and add to pq all edges from v to unmarked vertices.
+		marked[v] = true;
+		for (Edge e : G.adj(v)) {
+			if (!marked[e.other(v)])
+				pq.insert(e);
+		}
+	}
 
-    public Iterable<Edge> edges() {
-        return mst;
-    }
+	public Iterable<Edge> edges() {
+		return mst;
+	}
 
-    public double weight() // See Exercise 4.3.31.
+	public double weight() // See Exercise 4.3.31.
 }

--- a/src/q5/algo-SINF1121/summary/code/LinearProbing.java
+++ b/src/q5/algo-SINF1121/summary/code/LinearProbing.java
@@ -1,0 +1,70 @@
+public class LinearProbingHashST<Key, Value>
+{
+	private int N; // number of key-value pairs in the table
+	private int M; // size of linear-probing table
+	private Key[] keys;
+	private Values[] vals;
+
+	public LinearProbingHashST() {
+		this(4); // Initializes with an initial capacity of 4
+	}
+
+	public LinearProbingHashST(int capacity) {
+		M = capacity;
+		keys = (Key[]) new Object[M];
+		vals = (Value[]) new Object[M];
+	}
+
+	private int hash(Key key) {
+		return (key.hashCode() & 0x7fffffff) % M;
+	}
+
+	public void put(Key key, Value val) {
+		if(N >= M/2) resize(2*M);
+
+		int i;
+		for(i = hash(key); keys[i] != null; i = (i + 1) % M) {
+			if(keys[i].equals(key)) {
+				vals[i] = val;
+				return;
+			}
+		}
+
+		keys[i] = key;
+		vals[i] = val;
+		N++;
+	}
+
+	public Value get(Key key) {
+		for(int i = hash(key); keys[i] != null; i = (i + 1) % M) {
+			if(keys[i].equals(key)) {
+				return vals[i];
+			}
+		}
+
+		return null;
+	}
+
+	public void delete(Key key) {
+		if(!contains(key)) return;
+		int i = hash(key);
+		while(!key.equals(keys[i]))
+			i = (i + 1) % M;
+		keys[i] = null;
+		vals[i] = null;
+		i = (i + 1) % M;
+		while(keys[i] != null) {
+			Key keyToRedo = keys[i];
+			Value valToRedo = vals[i];
+			keys[i] = null;
+			vals[i] = null;
+			N--;
+			put(keyToRedo, valToRedo);
+			i = (i + 1) % M;
+		}
+
+		N--;
+		if(N > 0 && N <= M/8)
+			resize(M/2);
+	}
+}

--- a/src/q5/algo-SINF1121/summary/code/LinearProbing.java
+++ b/src/q5/algo-SINF1121/summary/code/LinearProbing.java
@@ -1,5 +1,4 @@
-public class LinearProbingHashST<Key, Value>
-{
+public class LinearProbingHashST<Key, Value> {
 	private int N; // number of key-value pairs in the table
 	private int M; // size of linear-probing table
 	private Key[] keys;
@@ -20,10 +19,10 @@ public class LinearProbingHashST<Key, Value>
 	}
 
 	public void put(Key key, Value val) {
-		if(N >= M/2) resize(2*M);
+		if (N >= M/2) resize(2*M);
 
 		int i;
-		for(i = hash(key); keys[i] != null; i = (i + 1) % M) {
+		for (i = hash(key); keys[i] != null; i = (i + 1) % M) {
 			if(keys[i].equals(key)) {
 				vals[i] = val;
 				return;
@@ -46,14 +45,15 @@ public class LinearProbingHashST<Key, Value>
 	}
 
 	public void delete(Key key) {
-		if(!contains(key)) return;
+		if (!contains(key))
+			return;
 		int i = hash(key);
-		while(!key.equals(keys[i]))
+		while (!key.equals(keys[i]))
 			i = (i + 1) % M;
 		keys[i] = null;
 		vals[i] = null;
 		i = (i + 1) % M;
-		while(keys[i] != null) {
+		while (keys[i] != null) {
 			Key keyToRedo = keys[i];
 			Value valToRedo = vals[i];
 			keys[i] = null;
@@ -64,7 +64,7 @@ public class LinearProbingHashST<Key, Value>
 		}
 
 		N--;
-		if(N > 0 && N <= M/8)
+		if (N > 0 && N <= M/8)
 			resize(M/2);
 	}
 }

--- a/src/q5/algo-SINF1121/summary/code/LongestPrefixOf.java
+++ b/src/q5/algo-SINF1121/summary/code/LongestPrefixOf.java
@@ -1,14 +1,15 @@
-public String longestPrefixOf(String s)
-{
+public String longestPrefixOf(String s) {
 	int length = search(root, s, 0, 0);
 	return s.substring(0, length);
 }
 
-private int search(Node x, String s, int d, int length)
-{
-	if (x == null) return length;
-	if (x.val != null) length = d;
-	if (d == s.length()) return length;
+private int search(Node x, String s, int d, int length) {
+	if (x == null)
+		return length;
+	if (x.val != null)
+		length = d;
+	if (d == s.length())
+		return length;
 	char c = s.charAt(d);
 	return search(x.next[c], s, d+1, length);
 }

--- a/src/q5/algo-SINF1121/summary/code/LongestPrefixOf.java
+++ b/src/q5/algo-SINF1121/summary/code/LongestPrefixOf.java
@@ -1,0 +1,14 @@
+public String longestPrefixOf(String s)
+{
+	int length = search(root, s, 0, 0);
+	return s.substring(0, length);
+}
+
+private int search(Node x, String s, int d, int length)
+{
+	if (x == null) return length;
+	if (x.val != null) length = d;
+	if (d == s.length()) return length;
+	char c = s.charAt(d);
+	return search(x.next[c], s, d+1, length);
+}

--- a/src/q5/algo-SINF1121/summary/code/MaxPQ.java
+++ b/src/q5/algo-SINF1121/summary/code/MaxPQ.java
@@ -6,8 +6,13 @@ public class MaxPQ<Key extends Comparable<Key>> {
 		pq = (Key[]) new Comparable[maxN+1];
 	}
 
-	public boolean isEmpty() { return N == 0; }
-	public int size() { return N; }
+	public boolean isEmpty() {
+		return N == 0;
+	}
+
+	public int size() {
+		return N;
+	}
 
 	public void insert(Key v) {
 		pq[++N] = v;

--- a/src/q5/algo-SINF1121/summary/code/MaxPQ.java
+++ b/src/q5/algo-SINF1121/summary/code/MaxPQ.java
@@ -1,0 +1,24 @@
+public class MaxPQ<Key extends Comparable<Key>> {
+	private Key[] pq;
+	private int N = 0;
+
+	public MaxPQ(int maxN) {
+		pq = (Key[]) new Comparable[maxN+1];
+	}
+
+	public boolean isEmpty() { return N == 0; }
+	public int size() { return N; }
+
+	public void insert(Key v) {
+		pq[++N] = v;
+		swim(N);
+	}
+
+	public Key delMax() {
+		Key max = pq[1];
+		exch(1, N--);
+		pq[N+1] = null;
+		sink(1);
+		return max;
+	}
+}

--- a/src/q5/algo-SINF1121/summary/code/Merge.java
+++ b/src/q5/algo-SINF1121/summary/code/Merge.java
@@ -12,5 +12,5 @@ public class Merge {
 		sort(a, aux, lo, mid);
 		sort(a, aux, mid + 1, hi);
 		merge(a, aux, lo, mid, hi);
-    }
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/Merge.java
+++ b/src/q5/algo-SINF1121/summary/code/Merge.java
@@ -4,12 +4,13 @@ public class Merge {
 		sort(a, aux, 0, a.length-1);
 	}
 
-    // mergesort a[lo..hi] using auxiliary array aux[lo..hi]
-    private static void sort(Comparable[] a, Comparable[] aux, int lo, int hi) {
-        if (hi <= lo) return;
-        int mid = lo + (hi - lo) / 2;
-        sort(a, aux, lo, mid);
-        sort(a, aux, mid + 1, hi);
-        merge(a, aux, lo, mid, hi);
+	// mergesort a[lo..hi] using auxiliary array aux[lo..hi]
+	private static void sort(Comparable[] a, Comparable[] aux, int lo, int hi) {
+		if (hi <= lo)
+			return;
+		int mid = lo + (hi - lo) / 2;
+		sort(a, aux, lo, mid);
+		sort(a, aux, mid + 1, hi);
+		merge(a, aux, lo, mid, hi);
     }
 }

--- a/src/q5/algo-SINF1121/summary/code/MergeBU.java
+++ b/src/q5/algo-SINF1121/summary/code/MergeBU.java
@@ -1,13 +1,14 @@
 public class MergeBU {
-    public static void sort(Comparable[] a) {
-        int N = a.length;
-        Comparable[] aux = new Comparable[N];
-        for (int n = 1; n < N; n = n+n) {
-            for (int i = 0; i < N-n; i += n+n) {
-                int lo = i;
-                int m  = i+n-1;
-                int hi = Math.min(i+n+n-1, N-1);
-                merge(a, aux, lo, m, hi);
-            }
-    }
+	public static void sort(Comparable[] a) {
+		int N = a.length;
+		Comparable[] aux = new Comparable[N];
+		for (int n = 1; n < N; n = n+n) {
+			for (int i = 0; i < N-n; i += n+n) {
+				int lo = i;
+				int m  = i+n-1;
+				int hi = Math.min(i+n+n-1, N-1);
+				merge(a, aux, lo, m, hi);
+			}
+		}
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/Node.java
+++ b/src/q5/algo-SINF1121/summary/code/Node.java
@@ -1,0 +1,4 @@
+private class Node {
+	private Item item;
+	private Node next;
+}

--- a/src/q5/algo-SINF1121/summary/code/NodeClass.java
+++ b/src/q5/algo-SINF1121/summary/code/NodeClass.java
@@ -1,0 +1,10 @@
+public class Node {
+     private Key key;
+     private Value val;
+     private Node left, right;
+     private int N;
+
+     public Node(Key key, Value val, int N) {
+          this.key = key; this.val = val; this.N = N;
+     }
+}

--- a/src/q5/algo-SINF1121/summary/code/NodeClass.java
+++ b/src/q5/algo-SINF1121/summary/code/NodeClass.java
@@ -1,10 +1,12 @@
 public class Node {
-     private Key key;
-     private Value val;
-     private Node left, right;
-     private int N;
+	private Key key;
+	private Value val;
+	private Node left, right;
+	private int N;
 
-     public Node(Key key, Value val, int N) {
-          this.key = key; this.val = val; this.N = N;
-     }
+	public Node(Key key, Value val, int N) {
+		this.key = key;
+		this.val = val;
+		this.N = N;
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/NodeGet.java
+++ b/src/q5/algo-SINF1121/summary/code/NodeGet.java
@@ -1,0 +1,12 @@
+public Value get(Key key) {
+     return get(root, key);
+}
+
+private Value get(Node x, Key key) {
+     if (x == null) return null;
+
+     int cmp = key.compareTo(x.key);
+     if      (cmp > 0) return get(x.right, key);
+     else if (cmp < 0) return get(x.left, key);
+     else	 return x.val;
+}

--- a/src/q5/algo-SINF1121/summary/code/NodeGet.java
+++ b/src/q5/algo-SINF1121/summary/code/NodeGet.java
@@ -1,12 +1,16 @@
 public Value get(Key key) {
-     return get(root, key);
+	return get(root, key);
 }
 
 private Value get(Node x, Key key) {
-     if (x == null) return null;
+	if (x == null)
+		return null;
 
-     int cmp = key.compareTo(x.key);
-     if      (cmp > 0) return get(x.right, key);
-     else if (cmp < 0) return get(x.left, key);
-     else	 return x.val;
+	int cmp = key.compareTo(x.key);
+	if (cmp > 0)
+		return get(x.right, key);
+	else if (cmp < 0)
+		return get(x.left, key);
+	else
+		return x.val;
 }

--- a/src/q5/algo-SINF1121/summary/code/NodePut.java
+++ b/src/q5/algo-SINF1121/summary/code/NodePut.java
@@ -1,0 +1,14 @@
+public void put(Key key, Value val) {
+     root = put(root, key, val);
+}
+
+private Node put(Node x, Key key, Value val) {
+     if (x == null) return new Node(key, val, 1);
+
+     int cmp = key.compareTo(x.key);
+     if      (cmp > 0) x.right = put(x.right, key, val);
+     else if (cmp < 0) x.left = put(x.left, key, val);
+     else x.val = val;
+     x.N = size(x.left) + size(x.right) + 1;
+     return x;
+}

--- a/src/q5/algo-SINF1121/summary/code/NodePut.java
+++ b/src/q5/algo-SINF1121/summary/code/NodePut.java
@@ -1,14 +1,18 @@
 public void put(Key key, Value val) {
-     root = put(root, key, val);
+	root = put(root, key, val);
 }
 
 private Node put(Node x, Key key, Value val) {
-     if (x == null) return new Node(key, val, 1);
+	if (x == null)
+		return new Node(key, val, 1);
 
-     int cmp = key.compareTo(x.key);
-     if      (cmp > 0) x.right = put(x.right, key, val);
-     else if (cmp < 0) x.left = put(x.left, key, val);
-     else x.val = val;
-     x.N = size(x.left) + size(x.right) + 1;
-     return x;
+	int cmp = key.compareTo(x.key);
+	if (cmp > 0)
+		x.right = put(x.right, key, val);
+	else if (cmp < 0)
+		x.left = put(x.left, key, val);
+	else
+		x.val = val;
+	x.N = size(x.left) + size(x.right) + 1;
+	return x;
 }

--- a/src/q5/algo-SINF1121/summary/code/NodeRotate.java
+++ b/src/q5/algo-SINF1121/summary/code/NodeRotate.java
@@ -1,17 +1,21 @@
 private Node rotateLeft(Node h) {
-     Node x = h.right;
-     h.right = x.left; x.left = h;
-     x.color = h.color; h.color = RED;
-     x.N = h.N;
-     h.N = 1 + size(h.left) + size(h.right);
-     return x;
+	Node x = h.right;
+	h.right = x.left;
+	x.left = h;
+	x.color = h.color;
+	h.color = RED;
+	x.N = h.N;
+	h.N = 1 + size(h.left) + size(h.right);
+	return x;
 }
 
 private Node rotateRight(Node h) {
-     Node x = h.left;
-     h.left = x.right; x.right = h;
-     x.color = h.color; h.color = RED;
-     x.N = h.N;
-     h.N = 1 + size(h.left) + size(h.right);
-     return x;
+	Node x = h.left;
+	h.left = x.right;
+	x.right = h;
+	x.color = h.color;
+	h.color = RED;
+	x.N = h.N;
+	h.N = 1 + size(h.left) + size(h.right);
+	return x;
 }

--- a/src/q5/algo-SINF1121/summary/code/NodeRotate.java
+++ b/src/q5/algo-SINF1121/summary/code/NodeRotate.java
@@ -1,0 +1,17 @@
+private Node rotateLeft(Node h) {
+     Node x = h.right;
+     h.right = x.left; x.left = h;
+     x.color = h.color; h.color = RED;
+     x.N = h.N;
+     h.N = 1 + size(h.left) + size(h.right);
+     return x;
+}
+
+private Node rotateRight(Node h) {
+     Node x = h.left;
+     h.left = x.right; x.right = h;
+     x.color = h.color; h.color = RED;
+     x.N = h.N;
+     h.N = 1 + size(h.left) + size(h.right);
+     return x;
+}

--- a/src/q5/algo-SINF1121/summary/code/Postorder.java
+++ b/src/q5/algo-SINF1121/summary/code/Postorder.java
@@ -1,0 +1,7 @@
+public static void postOrder(Node h) {
+	if(t != null) {
+		postOrder(t.left);
+		postOrder(t.right);
+		visit(t);
+	}
+}

--- a/src/q5/algo-SINF1121/summary/code/Postorder.java
+++ b/src/q5/algo-SINF1121/summary/code/Postorder.java
@@ -1,5 +1,5 @@
 public static void postOrder(Node h) {
-	if(t != null) {
+	if (t != null) {
 		postOrder(t.left);
 		postOrder(t.right);
 		visit(t);

--- a/src/q5/algo-SINF1121/summary/code/Preorder.java
+++ b/src/q5/algo-SINF1121/summary/code/Preorder.java
@@ -1,5 +1,5 @@
 public static void preOrder(Node h) {
-	if(t != null) {
+	if (t != null) {
 		visit(t);
 		preOrder(t.left);
 		preOrder(t.right);

--- a/src/q5/algo-SINF1121/summary/code/Preorder.java
+++ b/src/q5/algo-SINF1121/summary/code/Preorder.java
@@ -1,0 +1,7 @@
+public static void preOrder(Node h) {
+	if(t != null) {
+		visit(t);
+		preOrder(t.left);
+		preOrder(t.right);
+	}
+}

--- a/src/q5/algo-SINF1121/summary/code/Put.java
+++ b/src/q5/algo-SINF1121/summary/code/Put.java
@@ -1,14 +1,14 @@
-public void put(Key key, Value val)  {
-     int i = rank(key);
+public void put(Key key, Value val) {
+	int i = rank(key);
 
-     if (i < N && keys[i].compareTo(key) == 0) {
-          vals[i] = val; return;
-     }
+	if (i < N && keys[i].compareTo(key) == 0) {
+		vals[i] = val;
+		return;
+	}
 
-     for (int j = N; j > i; j--)  {
-          keys[j] = keys[j-1]; vals[j] = vals[j-1];
-     }
+	for (int j = N; j > i; j--) {
+		keys[j] = keys[j-1]; vals[j] = vals[j-1];
 
-     keys[i] = key; vals[i] = val;
-     N++;
+	keys[i] = key; vals[i] = val;
+	N++;
 }

--- a/src/q5/algo-SINF1121/summary/code/Put.java
+++ b/src/q5/algo-SINF1121/summary/code/Put.java
@@ -1,0 +1,14 @@
+public void put(Key key, Value val)  {
+     int i = rank(key);
+
+     if (i < N && keys[i].compareTo(key) == 0) {
+          vals[i] = val; return;
+     }
+
+     for (int j = N; j > i; j--)  {
+          keys[j] = keys[j-1]; vals[j] = vals[j-1];
+     }
+
+     keys[i] = key; vals[i] = val;
+     N++;
+}

--- a/src/q5/algo-SINF1121/summary/code/Queue.java
+++ b/src/q5/algo-SINF1121/summary/code/Queue.java
@@ -1,42 +1,51 @@
 public class Queue<Item> implements Iterable<Item> {
-    private int N;         // number of elements in queue
-    private Node first;    // beginning of queue
-    private Node last;     // end of queue
+	private int N;         // number of elements in queue
+	private Node first;    // beginning of queue
+	private Node last;     // end of queue
 
-    private class Node {
-        private Item item;
-        private Node next;
-    }
+	private class Node {
+		private Item item;
+		private Node next;
+	}
 
-    public Queue() {
-        first = null;
-        last  = null;
-    }
+	public Queue() {
+		first = null;
+		last  = null;
+	}
 
-    public boolean isEmpty()	{ return first == null; }
-	public int size()	{ return N; }
-    public int length()	{ return N; }
+	public boolean isEmpty() {
+		return first == null;
+	}
 
-    public void enqueue(Item item) {
-        Node x = new Node();
-        x.item = item;
-        if (isEmpty()) {
-            first = x;
-            last = x;
-        }
-        else {
-            last.next = x;
-            last = x;
-        }
-        N++;
-    }
+	public int size() {
+		return N;
+	}
 
-    public Item dequeue() {
-        if (isEmpty()) throw new RuntimeException("Queue underflow");
-        Item item = first.item;
-        first = first.next;
-        N--;
-        if (isEmpty()) last = null;   // to avoid loitering
-        return item;
-    }
+	public int length() {
+		return N;
+	}
+
+	public void enqueue(Item item) {
+		Node x = new Node();
+		x.item = item;
+		if (isEmpty()) {
+			first = x;
+			last = x;
+		} else {
+			last.next = x;
+			last = x;
+		}
+		N++;
+	}
+
+	public Item dequeue() {
+		if (isEmpty())
+			throw new RuntimeException("Queue underflow");
+		Item item = first.item;
+		first = first.next;
+		N--;
+		if (isEmpty())
+			last = null; // to avoid loitering
+		return item;
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/Queue.java
+++ b/src/q5/algo-SINF1121/summary/code/Queue.java
@@ -1,5 +1,5 @@
 public class Queue<Item> implements Iterable<Item> {
-    private int N;         // number of elements on queue
+    private int N;         // number of elements in queue
     private Node first;    // beginning of queue
     private Node last;     // end of queue
 

--- a/src/q5/algo-SINF1121/summary/code/Quick.java
+++ b/src/q5/algo-SINF1121/summary/code/Quick.java
@@ -1,40 +1,46 @@
 public class Quick {
-    public static void sort(Comparable[] a) {
-        StdRandom.shuffle(a);
-        sort(a, 0, a.length - 1);
-    }
+	public static void sort(Comparable[] a) {
+		StdRandom.shuffle(a);
+		sort(a, 0, a.length - 1);
+	}
 
-    // quicksort the subarray from a[lo] to a[hi]
-    private static void sort(Comparable[] a, int lo, int hi) {
-        if (hi <= lo) return;
-        int j = partition(a, lo, hi);
-        sort(a, lo, j-1);
-        sort(a, j+1, hi);
-    }
+	// quicksort the subarray from a[lo] to a[hi]
+	private static void sort(Comparable[] a, int lo, int hi) {
+		if (hi <= lo)
+			return;
+		int j = partition(a, lo, hi);
+		sort(a, lo, j-1);
+		sort(a, j+1, hi);
+	}
 
-    // partition the subarray a[lo..hi] so that a[lo..j-1] <= a[j] <= a[j+1..hi]
-    // and return the index j.
-    private static int partition(Comparable[] a, int lo, int hi) {
-        int i = lo;
-        int j = hi + 1;
-        Comparable v = a[lo];
-        while (true) {
-            // find item on lo to swap
-            while (less(a[++i], v))
-                if (i == hi) break;
+	// partition the subarray a[lo..hi] so that a[lo..j-1] <= a[j] <= a[j+1..hi]
+	// and return the index j.
+	private static int partition(Comparable[] a, int lo, int hi) {
+		int i = lo;
+		int j = hi + 1;
+		Comparable v = a[lo];
+		while (true) {
+			// find item on lo to swap
+			while (less(a[++i], v)) {
+				if (i == hi)
+					break;
+			}
 
-            // find item on hi to swap
-            while (less(v, a[--j]))
-                if (j == lo) break;      // redundant since a[lo] acts as sentinel
+			// find item on hi to swap
+			while (less(v, a[--j])) {
+				if (j == lo)
+					break; // redundant since a[lo] acts as sentinel
+			}
 
-            // check if pointers cross
-            if (i >= j) break;
+			// check if pointers cross
+			if (i >= j)
+				break;
 
-            exch(a, i, j);
-        }
-        // put partitioning item v at a[j]
-        exch(a, lo, j);
-        // now, a[lo .. j-1] <= a[j] <= a[j+1 .. hi]
-        return j;
-    }
+			exch(a, i, j);
+		}
+		// put partitioning item v at a[j]
+		exch(a, lo, j);
+		// now, a[lo .. j-1] <= a[j] <= a[j+1 .. hi]
+		return j;
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/Quick3way.java
+++ b/src/q5/algo-SINF1121/summary/code/Quick3way.java
@@ -1,24 +1,28 @@
 public class Quick3way {
-    public static void sort(Comparable[] a) {
-        StdRandom.shuffle(a);
-        sort(a, 0, a.length - 1);
-    }
+	public static void sort(Comparable[] a) {
+		StdRandom.shuffle(a);
+		sort(a, 0, a.length - 1);
+	}
 
-    // quicksort the subarray a[lo .. hi] using 3-way partitioning
-    private static void sort(Comparable[] a, int lo, int hi) {
-        if (hi <= lo) return;
-        int lt = lo, gt = hi;
-        Comparable v = a[lo];
-        int i = lo;
-        while (i <= gt) {
-            int cmp = a[i].compareTo(v);
-            if      (cmp < 0) exch(a, lt++, i++);
-            else if (cmp > 0) exch(a, i, gt--);
-            else              i++;
-        }
+	// quicksort the subarray a[lo .. hi] using 3-way partitioning
+	private static void sort(Comparable[] a, int lo, int hi) {
+		if (hi <= lo)
+			return;
+		int lt = lo, gt = hi;
+		Comparable v = a[lo];
+		int i = lo;
+		while (i <= gt) {
+			int cmp = a[i].compareTo(v);
+			if (cmp < 0)
+				exch(a, lt++, i++);
+			else if (cmp > 0)
+				exch(a, i, gt--);
+			else
+				i++;
+		}
 
-        // a[lo..lt-1] < v = a[lt..gt] < a[gt+1..hi].
-        sort(a, lo, lt-1);
-        sort(a, gt+1, hi);
-    }
+		// a[lo..lt-1] < v = a[lt..gt] < a[gt+1..hi].
+		sort(a, lo, lt-1);
+		sort(a, gt+1, hi);
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/RabinKarp.java
+++ b/src/q5/algo-SINF1121/summary/code/RabinKarp.java
@@ -1,5 +1,4 @@
-public class RabinKarp
-{
+public class RabinKarp {
 	private long patHash; // pattern hash value
 	private int M; // pattern length
 	private long Q; // a large prime
@@ -10,18 +9,16 @@ public class RabinKarp
 		M = pat.length();
 		Q = longRandomPrime();
 		RM = 1;
-		for (int i = 1; i <= M-1; i++) {
+		for (int i = 1; i <= M-1; i++)
 			RM = (R * RM) % Q;
-		}
 
 		patHash = hash(pat, M);
 	}
 
 	private long hash(String key, int M) {
 		long h = 0;
-		for(int j = 0; j < M; j++) {
+		for (int j = 0; j < M; j++)
 			h = (R * h + key.charAt(j)) % Q;
-		}
 
 		return h;
 	}
@@ -30,12 +27,13 @@ public class RabinKarp
 		int N = txt.length();
 		long txtHash = hash(txt, M);
 
-		if(patHash == txtHash)	return 0; // match
+		if (patHash == txtHash)
+			return 0; // match
 
-		for(int i = M; i < N; i++) {
+		for (int i = M; i < N; i++) {
 			txtHash = (txtHash + Q - RM*txt.charAt(i-M) % Q) % Q;
 			txtHash = (txtHash*R + txt.charAt(i)) % Q;
-			if(patHash == txtHash)
+			if (patHash == txtHash)
 				return (i - M + 1);
 		}
 

--- a/src/q5/algo-SINF1121/summary/code/RabinKarp.java
+++ b/src/q5/algo-SINF1121/summary/code/RabinKarp.java
@@ -1,0 +1,44 @@
+public class RabinKarp
+{
+	private long patHash; // pattern hash value
+	private int M; // pattern length
+	private long Q; // a large prime
+	private int R = 256; // alphabet size
+	private long RM; // R^(M-1) % Q for use in removing leading digit
+
+	public RabinKarp(String pat) {
+		M = pat.length();
+		Q = longRandomPrime();
+		RM = 1;
+		for (int i = 1; i <= M-1; i++) {
+			RM = (R * RM) % Q;
+		}
+
+		patHash = hash(pat, M);
+	}
+
+	private long hash(String key, int M) {
+		long h = 0;
+		for(int j = 0; j < M; j++) {
+			h = (R * h + key.charAt(j)) % Q;
+		}
+
+		return h;
+	}
+
+	private int search(String txt) {
+		int N = txt.length();
+		long txtHash = hash(txt, M);
+
+		if(patHash == txtHash)	return 0; // match
+
+		for(int i = M; i < N; i++) {
+			txtHash = (txtHash + Q - RM*txt.charAt(i-M) % Q) % Q;
+			txtHash = (txtHash*R + txt.charAt(i)) % Q;
+			if(patHash == txtHash)
+				return (i - M + 1);
+		}
+
+		return N; // no match
+	}
+}

--- a/src/q5/algo-SINF1121/summary/code/Rank.java
+++ b/src/q5/algo-SINF1121/summary/code/Rank.java
@@ -1,0 +1,12 @@
+public int rank(Key key) {
+     int lo = 0, hi = N-1;
+     while(lo <= hi) {
+          int mid = low + (hi - lo)/2;
+          int cmp = key.compareTo(keys[mid]);
+          if		(cmp < 0) hi = mid-1;
+          else if 	(cmp > 0) lo = mid+1;
+          else	 return mid;
+     }
+
+     return lo;
+}

--- a/src/q5/algo-SINF1121/summary/code/Rank.java
+++ b/src/q5/algo-SINF1121/summary/code/Rank.java
@@ -1,12 +1,15 @@
 public int rank(Key key) {
-     int lo = 0, hi = N-1;
-     while(lo <= hi) {
-          int mid = low + (hi - lo)/2;
-          int cmp = key.compareTo(keys[mid]);
-          if		(cmp < 0) hi = mid-1;
-          else if 	(cmp > 0) lo = mid+1;
-          else	 return mid;
-     }
+	int lo = 0, hi = N-1;
+	while (lo <= hi) {
+		int mid = low + (hi - lo)/2;
+		int cmp = key.compareTo(keys[mid]);
+		if (cmp < 0)
+			hi = mid-1;
+		else if (cmp > 0)
+			lo = mid+1;
+		else
+			return mid;
+	}
 
-     return lo;
+	return lo;
 }

--- a/src/q5/algo-SINF1121/summary/code/RedBlackBST.java
+++ b/src/q5/algo-SINF1121/summary/code/RedBlackBST.java
@@ -1,0 +1,3 @@
+public class RedBlackBST<Key extends Comparable<Key>, Value>
+{
+	private Node root;

--- a/src/q5/algo-SINF1121/summary/code/RedBlackBST.java
+++ b/src/q5/algo-SINF1121/summary/code/RedBlackBST.java
@@ -1,3 +1,2 @@
-public class RedBlackBST<Key extends Comparable<Key>, Value>
-{
+public class RedBlackBST<Key extends Comparable<Key>, Value> {
 	private Node root;

--- a/src/q5/algo-SINF1121/summary/code/RedBlackNode.java
+++ b/src/q5/algo-SINF1121/summary/code/RedBlackNode.java
@@ -2,18 +2,21 @@ private static final boolean RED = true;
 private static final boolean BLACK = false;
 
 private Class Node {
-     Key key; Value val;
-     Node left, right;
-     int N;
-     boolean color;
+	Key key; Value val;
+	Node left, right;
+	int N;
+	boolean color;
 
-     Node(Key key, Value val, int N, boolean color) {
-          this.key = key; this.val = val;
-          this.N = N; this.color = color;
-     }
+	Node(Key key, Value val, int N, boolean color) {
+		this.key = key;
+		this.val = val;
+		this.N = N;
+		this.color = color;
+	}
 }
 
 private boolean isRed(Node x) {
-     if(x == null) return false;
-     return x.color == RED;
+	if(x == null)
+		return false;
+	return x.color == RED;
 }

--- a/src/q5/algo-SINF1121/summary/code/RedBlackNode.java
+++ b/src/q5/algo-SINF1121/summary/code/RedBlackNode.java
@@ -1,0 +1,19 @@
+private static final boolean RED = true;
+private static final boolean BLACK = false;
+
+private Class Node {
+     Key key; Value val;
+     Node left, right;
+     int N;
+     boolean color;
+
+     Node(Key key, Value val, int N, boolean color) {
+          this.key = key; this.val = val;
+          this.N = N; this.color = color;
+     }
+}
+
+private boolean isRed(Node x) {
+     if(x == null) return false;
+     return x.color == RED;
+}

--- a/src/q5/algo-SINF1121/summary/code/RedBlackPut.java
+++ b/src/q5/algo-SINF1121/summary/code/RedBlackPut.java
@@ -1,0 +1,21 @@
+public void put(Key key, Value val) {
+     root = put(root, key, val);
+     root.color = BLACK;
+}
+
+private Node put(Node h, Key key, Value val) {
+     // Do standard insert, with red link to parent.
+     if(h == null) return new Node(key, val, 1, RED);
+
+     int cmp = key.compareTo(h.key);
+     if      (cmp > 0) h.right = put(h.right, key, val);
+     else if (cmp < 0) h.left = put(h.left, key, val);
+     else h.val = val;
+
+     if (isRed(h.left)  && isRed(h.left.left)) h = rotateRight(h);
+     if (!isRed(h.left) && isRed(h.right))     h = rotateLeft(h);
+     if (isRed(h.left)  && isRed(h.right))     flipColors(h);
+
+     h.N = 1 + size(h.left) + size(h.right);
+     return h:
+}

--- a/src/q5/algo-SINF1121/summary/code/RedBlackPut.java
+++ b/src/q5/algo-SINF1121/summary/code/RedBlackPut.java
@@ -1,21 +1,28 @@
 public void put(Key key, Value val) {
-     root = put(root, key, val);
-     root.color = BLACK;
+	root = put(root, key, val);
+	root.color = BLACK;
 }
 
 private Node put(Node h, Key key, Value val) {
-     // Do standard insert, with red link to parent.
-     if(h == null) return new Node(key, val, 1, RED);
+	// Do standard insert, with red link to parent.
+	if (h == null)
+		return new Node(key, val, 1, RED);
 
-     int cmp = key.compareTo(h.key);
-     if      (cmp > 0) h.right = put(h.right, key, val);
-     else if (cmp < 0) h.left = put(h.left, key, val);
-     else h.val = val;
+	int cmp = key.compareTo(h.key);
+	if (cmp > 0)
+		h.right = put(h.right, key, val);
+	else if (cmp < 0)
+		h.left = put(h.left, key, val);
+	else
+		h.val = val;
 
-     if (isRed(h.left)  && isRed(h.left.left)) h = rotateRight(h);
-     if (!isRed(h.left) && isRed(h.right))     h = rotateLeft(h);
-     if (isRed(h.left)  && isRed(h.right))     flipColors(h);
+	if (isRed(h.left)  && isRed(h.left.left))
+		h = rotateRight(h);
+	if (!isRed(h.left) && isRed(h.right))
+		h = rotateLeft(h);
+	if (isRed(h.left)  && isRed(h.right))
+		flipColors(h);
 
-     h.N = 1 + size(h.left) + size(h.right);
-     return h:
+	h.N = 1 + size(h.left) + size(h.right);
+	return h;
 }

--- a/src/q5/algo-SINF1121/summary/code/Resize.java
+++ b/src/q5/algo-SINF1121/summary/code/Resize.java
@@ -1,0 +1,13 @@
+private void resize(int cap) {
+	LinearProbingHashST<Key, Value> t;
+	t = new LinearProbingHashST<Key, Value>(cap);
+	for(int i = 0; i < M; i++) {
+		if(keys[i] != null) {
+			t.put(keys[i], vals[i]);
+		}
+	}
+
+	keys = t.keys;
+	vals = t.vals;
+	M = t.M;
+}

--- a/src/q5/algo-SINF1121/summary/code/Resize.java
+++ b/src/q5/algo-SINF1121/summary/code/Resize.java
@@ -2,9 +2,8 @@ private void resize(int cap) {
 	LinearProbingHashST<Key, Value> t;
 	t = new LinearProbingHashST<Key, Value>(cap);
 	for(int i = 0; i < M; i++) {
-		if(keys[i] != null) {
+		if(keys[i] != null)
 			t.put(keys[i], vals[i]);
-		}
 	}
 
 	keys = t.keys;

--- a/src/q5/algo-SINF1121/summary/code/Selection.java
+++ b/src/q5/algo-SINF1121/summary/code/Selection.java
@@ -1,12 +1,13 @@
 public class Selection {
-    public static void sort(Comparable[] a) {
-        int N = a.length;
-        for (int i = 0; i < N; i++) {
-            int min = i;
-            for (int j = i+1; j < N; j++) {
-                if (less(a[j], a[min])) min = j;
-            }
-            exch(a, i, min);
-        }
-    }
+	public static void sort(Comparable[] a) {
+		int N = a.length;
+		for (int i = 0; i < N; i++) {
+			int min = i;
+			for (int j = i+1; j < N; j++) {
+				if (less(a[j], a[min]))
+					min = j;
+			}
+			exch(a, i, min);
+		}
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/SeparateChaining.java
+++ b/src/q5/algo-SINF1121/summary/code/SeparateChaining.java
@@ -10,9 +10,8 @@ public class SeparateChainingHashST<Key, Value>
 	public SeparateChainingHashST(int M) {
 		this.M = M;
 		st = (SequentialSearchST<Key, Value>[]) new SequentialSearchST[M];
-		for(int i = 0; i < M; i++) {
+		for(int i = 0; i < M; i++)
 			st[i] = new SequentialSearchST();
-		}
 	}
 
 	private int hash(Key key) {

--- a/src/q5/algo-SINF1121/summary/code/SeparateChaining.java
+++ b/src/q5/algo-SINF1121/summary/code/SeparateChaining.java
@@ -1,0 +1,29 @@
+public class SeparateChainingHashST<Key, Value>
+{
+	private int M;
+	private SequentialSearchST<Key, Value>[] st;
+
+	public SeparateChainingHashST() {
+		this(997);   //default size to be 1000 faster than SequentialSearchST
+	}
+
+	public SeparateChainingHashST(int M) {
+		this.M = M;
+		st = (SequentialSearchST<Key, Value>[]) new SequentialSearchST[M];
+		for(int i = 0; i < M; i++) {
+			st[i] = new SequentialSearchST();
+		}
+	}
+
+	private int hash(Key key) {
+		return (key.hashCode() & 0x7fffffff) % M;
+	}
+
+	public Value get(Key key) {
+		return (Value) st[hash(key)].get(key);
+	}
+
+	public void put(Key key, Value val) {
+		st[hash(key)].put(key, val);
+	}
+}

--- a/src/q5/algo-SINF1121/summary/code/Shell.java
+++ b/src/q5/algo-SINF1121/summary/code/Shell.java
@@ -1,19 +1,20 @@
 public class Shell {
-    public static void sort(Comparable[] a) {
-        int N = a.length;
+	public static void sort(Comparable[] a) {
+		int N = a.length;
 
-        // 3x+1 increment sequence:  1, 4, 13, 40, 121, 364, 1093, ...
-        int h = 1;
-        while (h < N/3) h = 3*h + 1;
+		// 3x+1 increment sequence:  1, 4, 13, 40, 121, 364, 1093, ...
+		int h = 1;
+		while (h < N/3)
+			h = 3*h + 1;
 
-        while (h >= 1) {
-            // h-sort the array
-            for (int i = h; i < N; i++) {
-                for (int j = i; j >= h && less(a[j], a[j-h]); j -= h) {
-                    exch(a, j, j-h);
-                }
-            } 
-            h /= 3;
-        }
-    }
+		while (h >= 1) {
+		// h-sort the array
+			for (int i = h; i < N; i++) {
+				for (int j = i; j >= h && less(a[j], a[j-h]); j -= h) {
+					exch(a, j, j-h);
+				}
+			}
+			h /= 3;
+		}
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/Sink.java
+++ b/src/q5/algo-SINF1121/summary/code/Sink.java
@@ -1,0 +1,10 @@
+private void sink(int k) {
+	while(2*k <= N) {
+		int j = 2*k;
+		// Make j point to the larger of the two children
+		if(j < N && less(j, j+1)) j++;
+		if(!less(k, j)) break;
+		exch(k, j);
+		k = j;
+	}
+}

--- a/src/q5/algo-SINF1121/summary/code/Sink.java
+++ b/src/q5/algo-SINF1121/summary/code/Sink.java
@@ -1,9 +1,11 @@
 private void sink(int k) {
-	while(2*k <= N) {
+	while (2*k <= N) {
 		int j = 2*k;
 		// Make j point to the larger of the two children
-		if(j < N && less(j, j+1)) j++;
-		if(!less(k, j)) break;
+		if (j < N && less(j, j+1))
+			j++;
+		if (!less(k, j))
+			break;
 		exch(k, j);
 		k = j;
 	}

--- a/src/q5/algo-SINF1121/summary/code/Size.java
+++ b/src/q5/algo-SINF1121/summary/code/Size.java
@@ -1,8 +1,10 @@
 public int size() {
-     return size(root);
+	return size(root);
 }
 
 private int size(Node x) {
-     if (x == null) return 0;
-     else return x.N;
+	if (x == null)
+		return 0;
+	else
+		return x.N;
 }

--- a/src/q5/algo-SINF1121/summary/code/Size.java
+++ b/src/q5/algo-SINF1121/summary/code/Size.java
@@ -1,0 +1,8 @@
+public int size() {
+     return size(root);
+}
+
+private int size(Node x) {
+     if (x == null) return 0;
+     else return x.N;
+}

--- a/src/q5/algo-SINF1121/summary/code/SortTemplate.java
+++ b/src/q5/algo-SINF1121/summary/code/SortTemplate.java
@@ -1,20 +1,20 @@
 public class SortTemplate {
-public static void sort(Comparable[] a) { /* ... */}
+	public static void sort(Comparable[] a) {/* ... */}
 
-    private static boolean less(Comparable v, Comparable w) {
-        return v.compareTo(w) < 0;
-    }
+	private static boolean less(Comparable v, Comparable w) {
+		return v.compareTo(w) < 0;
+	}
 
-    private static void exch(Comparable[] a, int i, int j) {
-        Comparable swap = a[i];
-        a[i] = a[j];
-        a[j] = swap;
-    }
+	private static void exch(Comparable[] a, int i, int j) {
+		Comparable swap = a[i];
+		a[i] = a[j];
+		a[j] = swap;
+	}
 
-    // exchange a[i] and a[j]  (for indirect sort)
-    private static void exch(int[] a, int i, int j) {
-        int swap = a[i];
-        a[i] = a[j];
-        a[j] = swap;
-    }
+	// exchange a[i] and a[j]  (for indirect sort)
+	private static void exch(int[] a, int i, int j) {
+		int swap = a[i];
+		a[i] = a[j];
+		a[j] = swap;
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/Stack.java
+++ b/src/q5/algo-SINF1121/summary/code/Stack.java
@@ -1,33 +1,39 @@
 public class Stack<Item> implements Iterable<Item> {
-    private int N;          // size of the stack
-    private Node first;     // top of stack
+	private int N;          // size of the stack
+	private Node first;     // top of stack
 
-    private class Node {
-        private Item item;
-        private Node next;
-    }
+	private class Node {
+		private Item item;
+		private Node next;
+	}
 
-    public Stack() {
-        first = null;
-        N = 0;
-    }
+	public Stack() {
+		first = null;
+		N = 0;
+	}
 
-    public boolean isEmpty()	{ return first == null; }
-	public int size()	{ return N; }
+	public boolean isEmpty() {
+		return first == null;
+	}
 
-    public void push(Item item) {
-        Node oldfirst = first;
-        first = new Node();
-        first.item = item;
-        first.next = oldfirst;
-        N++;
-    }
+	public int size() {
+		return N;
+	}
 
-    public Item pop() {
-        if (isEmpty()) throw new RuntimeException("Stack underflow");
-        Item item = first.item;        // save item to return
-        first = first.next;            // delete first node
-        N--;
-        return item;                   // return the saved item
-    }
+	public void push(Item item) {
+		Node oldfirst = first;
+		first = new Node();
+		first.item = item;
+		first.next = oldfirst;
+		N++;
+	}
+
+	public Item pop() {
+		if (isEmpty())
+			throw new RuntimeException("Stack underflow");
+		Item item = first.item;        // save item to return
+		first = first.next;            // delete first node
+		N--;
+		return item;                   // return the saved item
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/Swim.java
+++ b/src/q5/algo-SINF1121/summary/code/Swim.java
@@ -1,5 +1,5 @@
 private void swim(int k) {
-	while(k > 1 && less(k/2, k)) {
+	while (k > 1 && less(k/2, k)) {
 		exch(k/2, k);
 		k = k/2;
 	}

--- a/src/q5/algo-SINF1121/summary/code/Swim.java
+++ b/src/q5/algo-SINF1121/summary/code/Swim.java
@@ -1,0 +1,6 @@
+private void swim(int k) {
+	while(k > 1 && less(k/2, k)) {
+		exch(k/2, k);
+		k = k/2;
+	}
+}

--- a/src/q5/algo-SINF1121/summary/code/TST.java
+++ b/src/q5/algo-SINF1121/summary/code/TST.java
@@ -1,43 +1,51 @@
-public class TST<Value>
-{
+public class TST<Value> {
+	private Node root;
 
-private Node root;
-private class Node
-{
-	char c;
-	Node left, mid, right;
-	Value val;
-}
+	private class Node {
+		char c;
+		Node left, mid, right;
+		Value val;
+	}
 
-public Value get(String key)
-// root of trie
-// character
-// left, middle, and right subtries
-// value associated with string
-// same as for tries (See page 737).
-private Node get(Node x, String key, int
-{
-	if (x == null) return null;
-	char c = key.charAt(d);
-	if(c < x.c) return get(x.left, key, d);
-	else if (c > x.c) return get(x.right, key, d);
-	else if (d < key.length() - 1)
-		return get(x.mid, key, d+1);
-	else return x;
-}
+	public Value get(String key)
+	// root of trie
+	// character
+	// left, middle, and right subtries
+	// value associated with string
+	// same as for tries (See page 737).
 
-public void put(String key, Value val)
-{ root = put(root, key, val, 0); }
+	private Node get(Node x, String key, int d) {
+		if (x == null)
+			return null;
+		char c = key.charAt(d);
+		if (c < x.c)
+			return get(x.left, key, d);
+		else if (c > x.c)
+			return get(x.right, key, d);
+		else if (d < key.length() - 1)
+			return get(x.mid, key, d+1);
+		else
+			return x;
+	}
 
-private Node put(Node x, String key, Value val, int d)
-{
-	char c = key.charAt(d);
-	if (x == null) { x = new Node(); x.c = c; }
-	if(c < x.c) x.left = put(x.left, key, val, d);
-	else if (c > x.c) x.right = put(x.right, key, val, d);
-	else if (d < key.length() - 1)
-	x.mid= put(x.mid,key, val, d+1);
-	else x.val = val;
-	return x;
-}
+	public void put(String key, Value val) {
+		root = put(root, key, val, 0);
+	}
+
+	private Node put(Node x, String key, Value val, int d) {
+		char c = key.charAt(d);
+		if (x == null) {
+			x = new Node();
+			x.c = c;
+		}
+		if (c < x.c)
+			x.left = put(x.left, key, val, d);
+		else if (c > x.c)
+			x.right = put(x.right, key, val, d);
+		else if (d < key.length() - 1)
+			x.mid= put(x.mid,key, val, d+1);
+		else
+			x.val = val;
+		return x;
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/TST.java
+++ b/src/q5/algo-SINF1121/summary/code/TST.java
@@ -1,0 +1,43 @@
+public class TST<Value>
+{
+
+private Node root;
+private class Node
+{
+	char c;
+	Node left, mid, right;
+	Value val;
+}
+
+public Value get(String key)
+// root of trie
+// character
+// left, middle, and right subtries
+// value associated with string
+// same as for tries (See page 737).
+private Node get(Node x, String key, int
+{
+	if (x == null) return null;
+	char c = key.charAt(d);
+	if(c < x.c) return get(x.left, key, d);
+	else if (c > x.c) return get(x.right, key, d);
+	else if (d < key.length() - 1)
+		return get(x.mid, key, d+1);
+	else return x;
+}
+
+public void put(String key, Value val)
+{ root = put(root, key, val, 0); }
+
+private Node put(Node x, String key, Value val, int d)
+{
+	char c = key.charAt(d);
+	if (x == null) { x = new Node(); x.c = c; }
+	if(c < x.c) x.left = put(x.left, key, val, d);
+	else if (c > x.c) x.right = put(x.right, key, val, d);
+	else if (d < key.length() - 1)
+	x.mid= put(x.mid,key, val, d+1);
+	else x.val = val;
+	return x;
+}
+}

--- a/src/q5/algo-SINF1121/summary/code/TopologicalSort.java
+++ b/src/q5/algo-SINF1121/summary/code/TopologicalSort.java
@@ -1,19 +1,19 @@
 public class Topological {
-    private Iterable<Integer> order; // topological order
+	private Iterable<Integer> order; // topological order
 
-    public Topological(Digraph G) {
-        DirectedCycle cyclefinder = new DirectedCycle(G);
-        if (!cyclefinder.hasCycle()) {
-            DepthFirstOrder dfs = new DepthFirstOrder(G);
-            order = dfs.reversePost();
-        }
-    }
+	public Topological(Digraph G) {
+		DirectedCycle cyclefinder = new DirectedCycle(G);
+		if (!cyclefinder.hasCycle()) {
+			DepthFirstOrder dfs = new DepthFirstOrder(G);
+			order = dfs.reversePost();
+		}
+	}
 
-    public Iterable<Integer> order() {
-        return order;
-    }
+	public Iterable<Integer> order() {
+		return order;
+	}
 
-    public boolean isDAG() {
-        return order == null;
-    }
+	public boolean isDAG() {
+		return order == null;
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/TrieDelete.java
+++ b/src/q5/algo-SINF1121/summary/code/TrieDelete.java
@@ -1,0 +1,20 @@
+public void delete(String key)
+{ root = delete(root, key, 0); }
+
+private Node delete(Node x, String key, int d)
+{
+	if (x == null) return null;
+	if (d == key.length())
+		x.val = null;
+	else
+	{
+		char c = key.charAt(d);
+		x.next[c] = delete(x.next[c], key, d+1);
+	}
+
+	if (x.val != null) return x;
+
+	for (char c = 0; c < R; c++)
+		if (x.next[c] != null) return x;
+	return null;
+}

--- a/src/q5/algo-SINF1121/summary/code/TrieDelete.java
+++ b/src/q5/algo-SINF1121/summary/code/TrieDelete.java
@@ -1,20 +1,23 @@
-public void delete(String key)
-{ root = delete(root, key, 0); }
+public void delete(String key) {
+	root = delete(root, key, 0);
+}
 
-private Node delete(Node x, String key, int d)
-{
-	if (x == null) return null;
-	if (d == key.length())
+private Node delete(Node x, String key, int d) {
+	if (x == null)
+		return null;
+	if (d == key.length()) {
 		x.val = null;
-	else
-	{
+	} else {
 		char c = key.charAt(d);
 		x.next[c] = delete(x.next[c], key, d+1);
 	}
 
-	if (x.val != null) return x;
+	if (x.val != null)
+		return x;
 
-	for (char c = 0; c < R; c++)
-		if (x.next[c] != null) return x;
+	for (char c = 0; c < R; c++) {
+		if (x.next[c] != null)
+			return x;
+	}
 	return null;
 }

--- a/src/q5/algo-SINF1121/summary/code/TrieST.java
+++ b/src/q5/algo-SINF1121/summary/code/TrieST.java
@@ -1,0 +1,40 @@
+public class TrieST<Value>
+{
+
+   private static int R = 256; // radix or number of possible characters
+   private Node root;
+   // root of trie
+
+   private static class Node
+   {
+	private Object val;
+	private Node[] next = new Node[R];
+   }
+
+   public Value get(String key)
+   {
+	Node x = get(root, key, 0);
+	if (x == null) return null;
+	return (Value) x.val;
+   }
+
+   private Node get(Node x, String key, int d)
+   { // Return value associated with key in the subtrie rooted at x.
+ 	if (x == null) return null;
+	if (d == key.length()) return x;
+	char c = key.charAt(d); // Use dth key char to identify subtrie.
+	return get(x.next[c], key, d+1);
+   }
+
+   public void put(String key, Value val)
+   { root = put(root, key, val, 0); }
+
+   private Node put(Node x, String key, Value val, int d)
+   { // Change value associated with key if in subtrie rooted at x.
+	if (x == null) x = new Node();
+	if (d == key.length()) { x.val = val; return x; }
+	char c = key.charAt(d); // Use dth key char to identify subtrie.
+	x.next[c] = put(x.next[c], key, val, d+1);
+	return x;
+  }
+}

--- a/src/q5/algo-SINF1121/summary/code/TrieST.java
+++ b/src/q5/algo-SINF1121/summary/code/TrieST.java
@@ -1,40 +1,42 @@
-public class TrieST<Value>
-{
+public class TrieST<Value> {
+	private static int R = 256; // radix or number of possible characters
+	private Node root;
+	// root of trie
 
-   private static int R = 256; // radix or number of possible characters
-   private Node root;
-   // root of trie
+	private static class Node {
+		private Object val;
+		private Node[] next = new Node[R];
+	}
 
-   private static class Node
-   {
-	private Object val;
-	private Node[] next = new Node[R];
-   }
+	public Value get(String key) {
+		Node x = get(root, key, 0);
+		if (x == null)
+			return null;
+		return (Value) x.val;
+	}
 
-   public Value get(String key)
-   {
-	Node x = get(root, key, 0);
-	if (x == null) return null;
-	return (Value) x.val;
-   }
+	private Node get(Node x, String key, int d) { // Return value associated with key in the subtrie rooted at x.
+		if (x == null)
+			return null;
+		if (d == key.length())
+			return x;
+		char c = key.charAt(d); // Use dth key char to identify subtrie.
+		return get(x.next[c], key, d+1);
+	}
 
-   private Node get(Node x, String key, int d)
-   { // Return value associated with key in the subtrie rooted at x.
- 	if (x == null) return null;
-	if (d == key.length()) return x;
-	char c = key.charAt(d); // Use dth key char to identify subtrie.
-	return get(x.next[c], key, d+1);
-   }
+	public void put(String key, Value val) {
+		root = put(root, key, val, 0);
+	}
 
-   public void put(String key, Value val)
-   { root = put(root, key, val, 0); }
-
-   private Node put(Node x, String key, Value val, int d)
-   { // Change value associated with key if in subtrie rooted at x.
-	if (x == null) x = new Node();
-	if (d == key.length()) { x.val = val; return x; }
-	char c = key.charAt(d); // Use dth key char to identify subtrie.
-	x.next[c] = put(x.next[c], key, val, d+1);
-	return x;
-  }
+	private Node put(Node x, String key, Value val, int d) { // Change value associated with key if in subtrie rooted at x.
+		if (x == null)
+			x = new Node();
+		if (d == key.length()) {
+			x.val = val
+			return x;
+		}
+		char c = key.charAt(d); // Use dth key char to identify subtrie.
+		x.next[c] = put(x.next[c], key, val, d+1);
+		return x;
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/Union.java
+++ b/src/q5/algo-SINF1121/summary/code/Union.java
@@ -1,7 +1,8 @@
 public void union(int p, int q) {
 	int i = find(p);
 	int i = find(q);
-	if (i == j) return;
+	if (i == j)
+		return;
 
 	// Make root of the first tree point to the second
 	id[i] = j;

--- a/src/q5/algo-SINF1121/summary/code/Union.java
+++ b/src/q5/algo-SINF1121/summary/code/Union.java
@@ -1,0 +1,9 @@
+public void union(int p, int q) {
+	int i = find(p);
+	int i = find(q);
+	if (i == j) return;
+
+	// Make root of the first tree point to the second
+	id[i] = j;
+	count--;
+}

--- a/src/q5/algo-SINF1121/summary/code/UnionFind.java
+++ b/src/q5/algo-SINF1121/summary/code/UnionFind.java
@@ -1,0 +1,28 @@
+public class UF {
+	private int[] id;	// access to component id (site indexed)
+	private int count;	// number of components
+
+	public UF(int N) {
+		count = N;
+		id = new int[N];
+		for(int i = 0; i < N; i++) {
+			id[i] = i;
+		}
+	}
+
+	public int count() { return count; }
+	public boolean connected(int p, int q) { return find(p) == find(q);	}
+	public int find(int p) {return id[p];}
+
+	public void union(int p, int q) {
+		int pID = find(p);
+		int qID = find(q);
+
+		if(pID == qID) return;
+
+		for(int i = 0; i < id.length; i++)
+			if(id[i] == pID) id[i] = qID;
+
+		count--;
+	}
+}

--- a/src/q5/algo-SINF1121/summary/code/UnionFind.java
+++ b/src/q5/algo-SINF1121/summary/code/UnionFind.java
@@ -5,23 +5,34 @@ public class UF {
 	public UF(int N) {
 		count = N;
 		id = new int[N];
-		for(int i = 0; i < N; i++) {
+		for (int i = 0; i < N; i++) {
 			id[i] = i;
 		}
 	}
 
-	public int count() { return count; }
-	public boolean connected(int p, int q) { return find(p) == find(q);	}
-	public int find(int p) {return id[p];}
+	public int count() {
+		return count;
+	}
+
+	public boolean connected(int p, int q) {
+		return find(p) == find(q);
+	}
+
+	public int find(int p) {
+		return id[p];
+	}
 
 	public void union(int p, int q) {
 		int pID = find(p);
 		int qID = find(q);
 
-		if(pID == qID) return;
+		if (pID == qID)
+			return;
 
-		for(int i = 0; i < id.length; i++)
-			if(id[i] == pID) id[i] = qID;
+		for (int i = 0; i < id.length; i++) {
+			if(id[i] == pID)
+				id[i] = qID;
+		}
 
 		count--;
 	}

--- a/src/q5/algo-SINF1121/summary/code/WeightedQuickUnion.java
+++ b/src/q5/algo-SINF1121/summary/code/WeightedQuickUnion.java
@@ -6,27 +6,41 @@ public class WeightedQuickUnionUF {
 	public WeightedQuickUnionUF(int N) {
 		count = N;
 		id = new int[N];
-		for(int i = 0; i < N; i++)	id[i] = i;
+		for (int i = 0; i < N; i++)
+			id[i] = i;
 		sz = new int[N];
-		for(int i = 	0; i < N; i++) 	sz[i} = 1;
+		for (int i = 	0; i < N; i++)
+			sz[i} = 1;
 	}
 
-	public int count() { return count; }
-	public boolean connected(int p, int q) { return find(p) == find(q);	}
+	public int count() {
+		return count;
+	}
+
+	public boolean connected(int p, int q) {
+		return find(p) == find(q);
+	}
 
 	public int find(int p) {
-		while(p != id[p]) p = id[p];
+		while (p != id[p])
+			p = id[p];
 		return p;
 	}
 
 	public void union(int p, int q) {
 		int i = find(p);
 		int j = find(q);
-		if(i == j) return;
+		if (i == j)
+			return;
 
 		// Make smaller root point to the larger one
-		if		(sz[i] < sz[j]) 	{ id[i] = j; sz[j] += sz[i]; }
-		else						{ id[j] = i; sz[i] += sz[j]; }
+		if (sz[i] < sz[j]) {
+			id[i] = j;
+			sz[j] += sz[i];
+		} else {
+			id[j] = i;
+			sz[i] += sz[j];
+		}
 
 		count--;
 	}

--- a/src/q5/algo-SINF1121/summary/code/WeightedQuickUnion.java
+++ b/src/q5/algo-SINF1121/summary/code/WeightedQuickUnion.java
@@ -9,7 +9,7 @@ public class WeightedQuickUnionUF {
 		for (int i = 0; i < N; i++)
 			id[i] = i;
 		sz = new int[N];
-		for (int i = 	0; i < N; i++)
+		for (int i = 0; i < N; i++)
 			sz[i} = 1;
 	}
 

--- a/src/q5/algo-SINF1121/summary/code/WeightedQuickUnion.java
+++ b/src/q5/algo-SINF1121/summary/code/WeightedQuickUnion.java
@@ -1,0 +1,33 @@
+public class WeightedQuickUnionUF {
+	private int[] id;	// access to component id (site indexed)
+	private int[] sz;	// size of component for roots (site indexed)
+	private int count;	// number of components
+
+	public WeightedQuickUnionUF(int N) {
+		count = N;
+		id = new int[N];
+		for(int i = 0; i < N; i++)	id[i] = i;
+		sz = new int[N];
+		for(int i = 	0; i < N; i++) 	sz[i} = 1;
+	}
+
+	public int count() { return count; }
+	public boolean connected(int p, int q) { return find(p) == find(q);	}
+
+	public int find(int p) {
+		while(p != id[p]) p = id[p];
+		return p;
+	}
+
+	public void union(int p, int q) {
+		int i = find(p);
+		int j = find(q);
+		if(i == j) return;
+
+		// Make smaller root point to the larger one
+		if		(sz[i] < sz[j]) 	{ id[i] = j; sz[j] += sz[i]; }
+		else						{ id[j] = i; sz[i] += sz[j]; }
+
+		count--;
+	}
+}

--- a/src/q5/algo-SINF1121/summary/code/mergeMethod.java
+++ b/src/q5/algo-SINF1121/summary/code/mergeMethod.java
@@ -1,20 +1,23 @@
 // stably merge a[lo .. mid] with a[mid+1 ..hi] using aux[lo .. hi]
 private static void merge(Comparable[] a, Comparable[] aux, int lo, int mid, int hi) {
-    // copy to aux[]
-    for (int k = lo; k <= hi; k++) {
-        aux[k] = a[k];
-    }
+	// copy to aux[]
+	for (int k = lo; k <= hi; k++)
+		aux[k] = a[k];
 
-    // merge back to a[]
-    int i = lo, j = mid+1;
-    for (int k = lo; k <= hi; k++) {
+	// merge back to a[]
+	int i = lo, j = mid+1;
+	for (int k = lo; k <= hi; k++) {
 		// left half exhausted
-        if      (i > mid)	a[k] = aux[j++];
+		if (i > mid)
+			a[k] = aux[j++];
 		// right half exhausted
-		else if (j > hi)	a[k] = aux[i++];
+		else if (j > hi)
+			a[k] = aux[i++];
 		// current key on right less than current key on left
-		else if (less(aux[j], aux[i]))	a[k] = aux[j++];
+		else if (less(aux[j], aux[i]))
+			a[k] = aux[j++];
 		// current key on right greater than or equal to current key on left
-        else	a[k] = aux[i++];
-    }
+		else
+			a[k] = aux[i++];
+	}
 }

--- a/src/q5/algo-SINF1121/summary/code/mergeMethod.java
+++ b/src/q5/algo-SINF1121/summary/code/mergeMethod.java
@@ -14,7 +14,7 @@ private static void merge(Comparable[] a, Comparable[] aux, int lo, int mid, int
 		else if (j > hi)	a[k] = aux[i++];
 		// current key on right less than current key on left
 		else if (less(aux[j], aux[i]))	a[k] = aux[j++];
-		// current key on right greater than or equal current key on left
+		// current key on right greater than or equal to current key on left
         else	a[k] = aux[i++];
     }
 }


### PR DESCRIPTION
Various fixes to the algo summary: reorganizing code, adding a
table, fixing spelling errors, making definitions and propositons and
whatnot pop out more, translating a part of the summary from French to
English, moving the interval construct to a new preamble document and
updating the place where it was previously used accordingly, fixing
image alignment in algo summary, fixing logarithms in big-o notations.