### PR TITLE
Minor fixes to math 3 exam 2018 janvier

### DIFF
--- a/src/q3/math-FSAB1103/exam/2018/Janvier/All/math-FSAB1103-exam-2018-Janvier-All.tex
+++ b/src/q3/math-FSAB1103/exam/2018/Janvier/All/math-FSAB1103-exam-2018-Janvier-All.tex
@@ -154,7 +154,7 @@ et $\int\frac{\mathrm{d}\eta}{\cosh(a\eta)}=\frac{2}{a}\arctan(e^{a\eta})$.
 
 	A la place, autant bien lire les consignes et remarquer qu'on nous demande de trouver une relation pour $cu$, et non pour $u$.
 	L'étudiant attentif et ayant lu son syllabus se souviendra que
-	dans le cas de l'équation de transport sous forme conservative $\fpart{c(x) u}{x} + \fpart{u}{t} = 0$,
+	dans le cas de l'équation de transport sous forme conservative $\fpart{(c(x) u)}{x} + \fpart{u}{t} = 0$,
 	le terme $cu$ est en fait constant le long des caractéristiques.
 	Ici, on n'a pas exactement l'équation de transport du syllabus\footnote{Ce serait probablement trop simple pour un examen,
 		se disent les professeurs.}, mais on peut quand même trouver quelque chose:
@@ -168,18 +168,21 @@ et $\int\frac{\mathrm{d}\eta}{\cosh(a\eta)}=\frac{2}{a}\arctan(e^{a\eta})$.
 
 	Dès lors, nous avons une relation pratique pour déterminer $u$ partout
 	(pour peu que $S$ ne dépende pas de $u$ évidemment; sinon on est de retour
-	aux problèmes précédents, et forcés d'utiliser des méthodes numériques)
+	aux problèmes précédents, et forcé d'utiliser des méthodes numériques)
 	\[ \dif{(cu)} = S \dif{x} \]
 
 	Appliquons-là au cas spécial $S=\frac{c_0 U}{L}$:
-	\begin{align}
-	\int_{(s, 0)}^{(x, t)} \dif{(cu)} &= \frac{c_0 U}{L} \int_{s}^{x} \dif{x} \nonumber \\
-	c(x) u(x, t) - c(s) u(s, 0) &= c_0 U \frac{x-s}{L} \nonumber \\
-	c(x) u(x, t) &= c(s) u(s, 0) + c_0 \frac{x-s}{L} U \nonumber \\
+	\begin{align*}
+	\int_{(s, 0)}^{(x, t)} \dif{(cu)} &= \frac{c_0 U}{L} \int_{s}^{x} \dif{x} \\
+	c(x) u(x, t) - c(s) u(s, 0) &= c_0 U \frac{x-s}{L} \\
+	c(x) u(x, t) &= c(s) u(s, 0) + c_0 \frac{x-s}{L} U \\
 	u(x, t) &= \frac{c(s)}{c(x)} u(s, 0) + \frac{c_0}{c(x)} \frac{x-s}{L} U
-	\end{align}
+	\end{align*}
 	ce qui donne finalement
-	\[ u(x, t) = \frac{\cosh\left(\frac{x}{L}\right)}{\cosh\left(\frac{s(x, t)}{L}\right)} U \exp\left( -\frac{s(, t)}{L_0} \right) + \cosh(\frac{x}{L}) \frac{x-s(x, t)}{L} U \qquad s(x, t) = L\arcsinh\left(\sinh\left(\frac{x}{L}\right)-\frac{c_0t}{L}\right), \]
+	\[
+	  u(x, t) = U \frac{\cosh\left(\frac{x}{L}\right)}{\cosh\left(\frac{s(x, t)}{L}\right)} \exp\left( -\frac{s(x, t)}{L_0} \right)
+	    + U \cosh\left(\frac{x}{L}\right) \frac{x-s(x, t)}{L},
+	\]
 	% Ancien développement, gardé pour raisons historiques (autant garder les calculs)
 %	\begin{align*}
 %	s &= L \cdot \arcsinh\left( \sinh\left(\frac{x}{L}\right) - \frac{c_0 t}{L} \right) \\
@@ -314,7 +317,7 @@ Par superposition des solutions, on a
 On peut donc écrire la solution de notre équation en terme de $D_n$ à calculer
 \begin{align*}
 u(x, y) & = u_0(x, y) + \sum_{n=0}^\infty D_n\sin(k_nx)\sinh(k_ny) \\
-& = U\frac{y}{H}\frac{x}{L} + \sum_{n=1}^\infty D_n\sin(k_nx)\sinh(k_ny) \qquad k_n=\frac{n\pi}{L}. \\
+& = U\frac{y}{H}\frac{x}{L} + \sum_{n=1}^\infty D_n\sin(k_nx)\sinh(k_ny) \qquad k_n=\frac{n\pi}{L}.
 \end{align*}
 Il reste la dernière condition sur le bord (2) pour déterminer les $D_n$.
 \[
@@ -339,7 +342,7 @@ D_n &= \frac{2}{L} \frac{1}{k_n \cosh(k_n H)} \frac{U}{H} \int^L_0 \left[ \sin\l
 &= \begin{cases}
 \frac{U}{H} \frac{1}{k_n \cosh(k_n H)} & \text{si } n=2 \\
 0 & \text{sinon}
-\end{cases} \\
+\end{cases}
 \end{align*}
 Finalement,
 \[ u(x, y) = U \frac{x}{L} \frac{y}{H}
@@ -372,7 +375,7 @@ où $g(z)$ est une fonction entière.
 Développons la fonction $f(z)$ en série de Laurent
 \begin{align*}
     e^z &= 1 + z + \frac{z^2}{2} + \frac{z^3}{6} + \dots = \sum_{n=0}^{\infty} \frac{1}{n!} z^n \\
-    e^{1/z} &= 1 + \frac{1}{z} + \frac{1}{2z^2} + \frac{1}{6z^3} + \dots = \sum_{n=0}^{\infty} \frac{1}{n!} z^{-n}. \\
+    e^{1/z} &= 1 + \frac{1}{z} + \frac{1}{2z^2} + \frac{1}{6z^3} + \dots = \sum_{n=0}^{\infty} \frac{1}{n!} z^{-n}.
 \end{align*}
 La fonction $g(z)$ étant entière, nous pouvons, elle-aussi,
 la développer en série de Taylor (donc de Laurent) autour de $z=0$:
@@ -387,7 +390,7 @@ Il suffit à présent de multiplier les deux séries et d'en extraire le coeffic
     =& \dots + \left( g'(0) + \frac{g''(0)}{2! \cdot 1!} + \frac{g'''(0)}{3! \cdot 2!} + \dots \right) z^{1} \\
     &+ \left(g(0) + g'(0)+ \frac{g''(0)}{(2!)^2} + \dots \right) z^0 \\
     &+ \left(\frac{g(0)}{0!\cdot 1!} + \frac{g'(0)}{1!\cdot 2!} + \frac{g''(0)}{2!\cdot 3!} + \dots \right) z^{-1} + \dots \\
-    =& \sum_{k=-\infty}^{\infty} \left( \sum_{m=\min(k, 0)}^{\infty} \frac{1}{m!} \frac{1}{(m-k)!} g^{(m)}(0) \right) z^{k}. \\
+    =& \sum_{k=-\infty}^{\infty} \left( \sum_{m=\min(k, 0)}^{\infty} \frac{1}{m!} \frac{1}{(m-k)!} g^{(m)}(0) \right) z^{k}.
 \end{align*}
 D'où on détermine le résidu:
 \begin{equation*}


### PR DESCRIPTION
J'ai visiblement du mal parfois ^^
Comme indiqué dans le commit, il y a quelques bugs avec les environnements solfig et solution qui font que la figure n'est pas parfaitement centrée dans le document produit, ainsi qu'un overfull hbox.
Je vais voir si c'est facilement réparable, ce n'est que cosmétique. J'ai aussi #396 qui m'attend.
(Fun fact: pour tester, tout a été fait depuis Gitkraken, y compris la PR.)