### PR TITLE
Fix issue #585

### DIFF
--- a/src/eplbase.cls
+++ b/src/eplbase.cls
@@ -100,13 +100,12 @@
 \typeout{You have an old version of Tikz: \pgfversion, try to update some time ;)}
 \fi
 
-% Execute bash commands: be sure to have bashful.sty on your pc!
-\usepackage{bashful}
-
 \ifdefined\COMMITINFOS
 
 \ifdefined\DATUM
 \else
+% Execute bash commands: be sure to have bashful.sty on your pc!
+\usepackage{bashful}
 \bash[stdoutFile=\jobname-date.stdout]
 echo $(git log -n 1 --pretty=format:\%ai "$(basename $(ls *.stderr) .stderr).tex" | sed -r 's/([0-9]+)-([0-9]+)-([0-9]+) ([0-9]+):([0-9]+):([0-9]+) ([^ ]+)/\3\/\2\/\1 (\4\:\5\)/')
 \END


### PR DESCRIPTION
Le problème est dû au chargement du package `bashful` que j'avais inséré début juillet pour avoir accès aux ID et date du dernier commit. Je requiers maintenant ce package uniquement si on veut ces informations. Donc, dans la plupart du temps, le manque du package `listings` génèrera une erreur.

PS: Top 3 in terms of commits arrives soon :3rd_place_medal: 

Closes #585.