### PR TITLE
BIR1304 - Correction de la correction d'examen

### DIFF
--- a/src/q5/stat-BIR1304/exam/2011/Septembre/All/stat-BIR1304-exam-2011-Septembre-All.tex
+++ b/src/q5/stat-BIR1304/exam/2011/Septembre/All/stat-BIR1304-exam-2011-Septembre-All.tex
@@ -12,105 +12,62 @@
 Un agriculteur possède un champ carré de longueur $\mu$, dont il désire estimer la surface. Pour cela, il effectue 2 mesures indépendantes $X_{1}$ et $X_{2}$ de la longueur de son champs telles que ces mesures suivent une loi normale d'espérance $\mu$ et de variance $\sigma^{2}$. Pour estimer la surface, plusieurs possibilités s'offrent à lui. Il peut faire la moyenne des mesures et l'élever au carré, ou bien il peut élever les mesures au carré et prendre leur moyenne. Une troisième solution revient à multiplier les 2 mesures. Les trois estimateurs correspondants sont les suivants :
 
 
-
-  \[
-   \hat{\theta_{1}} = \frac{{(X_{1} + X_{2})}^{2}}{4}
-  \]
-
-  \[
-   \hat{\theta_{2}} = \frac{(X_{1}^{2} + X_{2}^{2})}{2}
-  \]
-
-  \[
-   \hat{\theta_{3}} = X_{1} \times X_{2}
-  \] \bigskip
+\begin{align}
+	\label{para1} \widehat{\theta_{1}} &= \frac{{(X_{1} + X_{2})}^{2}}{4} \\ 
+	\label{para2} \widehat{\theta_{2}} &= \frac{(X_{1}^{2} + X_{2}^{2})}{2} \\ 
+	\label{para3} \widehat{\theta_{3}} &= X_{1} \times X_{2} 
+\end{align}
+\bigskip
 
 \begin{solution}
-  Calcul du biais du paramètre $\hat{\theta_{1}}$ :
-
-  \[
-   E[\hat{\theta_{1}}] = E\left[\frac{{(X_{1} + X_{2})}^{2}}{4}\right]
-  \]
-  \[
-   = \frac{1}{4} \times E\left[{(X_{1} + X_{2})}^{2}\right]
-  \]
-  \[
-   = \frac{1}{4} \times E[X_{1}^{2} + 2 X_{1} X_{2} + X_{2}^{2}]
-  \]
-  \[
-   = \frac{1}{4} \times (E[X_{1}^{2}] + E[2 X_{1} X_{2}] + E[X_{2}^{2}])
-  \]
-  \[
-   = \frac{1}{4} \times (E[X_{1}^{2}] - E^{2}[X_{1}] + E^{2}[X_{1}] + E[2 X_{1} X_{2}] + E[X_{2}^{2}] - E^{2}[X_{2}] + E^{2}[X_{2}])
-  \]
-  \[
-   = \frac{1}{4} \times (\sigma^{2} + E^{2}[X_{1}] + E[2 X_{1} X_{2}] + \sigma^{2} + E^{2}[X_{2}])
-  \]
-  \[
-   = \frac{1}{4} \times (\sigma^{2} + \mu^{2} + E[2 X_{1} X_{2}] + \sigma^{2} + \mu^{2})
-  \]
+  Calcul du biais du paramètre $\widehat{\theta_{1}}$ donné par l'équation \ref{para1}:
+	\begin{align*}
+		 E[\widehat{\theta_{1}}] &= E\left[\frac{{(X_{1} + X_{2})}^{2}}{4}\right] \\
+		 &= \frac{1}{4} \times E\left[{(X_{1} + X_{2})}^{2}\right] \\
+		 &= \frac{1}{4} \times E[X_{1}^{2} + 2 X_{1} X_{2} + X_{2}^{2}] \\
+		 &= \frac{1}{4} \times (E[X_{1}^{2}] + E[2 X_{1} X_{2}] + E[X_{2}^{2}]) \\
+		 &= \frac{1}{4} \times (E[X_{1}^{2}] - E^{2}[X_{1}] + E^{2}[X_{1}] + E[2 X_{1} X_{2}] + E[X_{2}^{2}] - E^{2}[X_{2}] + E^{2}[X_{2}]) \\
+		 &= \frac{1}{4} \times (\sigma^{2} + E^{2}[X_{1}] + E[2 X_{1} X_{2}] + \sigma^{2} + E^{2}[X_{2}]) \\
+		 &= \frac{1}{4} \times (\sigma^{2} + \mu^{2} + E[2 X_{1} X_{2}] + \sigma^{2} + \mu^{2})
+	\end{align*}
 
   Puisque les 2 mesures sont indépendantes :
-  \[
-   = \frac{1}{4} * (\sigma^{2} + \mu^{2} + 2* E[X_{1}] * E[X_{2}] + \sigma^{2} + \mu^{2})
-  \]
-  \[
-   = \frac{1}{4} * (\sigma^{2} + \mu^{2} + 2* \mu * \mu + \sigma^{2} + \mu^{2})
-  \]
-  \[
-   = \frac{1}{4} * (\sigma^{2} + \mu^{2} + 2* \mu^{2} + \sigma^{2} + \mu^{2})
-  \]
-  \[
-   = \mu^{2} + \frac{\sigma^{2}}{2}
-  \]
+  
+  \begin{align*}
+  	&= \frac{1}{4} \times (\sigma^{2} + \mu^{2} + 2\: E[X_{1}] \: . \: E[X_{2}] + \sigma^{2} + \mu^{2}) \\
+	&= \frac{1}{4} \times (\sigma^{2} + \mu^{2} + 2\: \mu\ . \mu + \sigma^{2} + \mu^{2}) \\
+	&= \frac{1}{4} \times (\sigma^{2} + \mu^{2} + 2\: \mu^{2} + \sigma^{2} + \mu^{2}) \\
+	&= \mu^{2} + \frac{\sigma^{2}}{2}
+  \end{align*}
 
   Le biais est donc de $\frac{\sigma^{2}}{2}$
+  
+  \pagebreak[2]
 
-
-  \bigskip
-
-  Calcul du biais du paramètre $\hat{\theta_{2}}$ :
-
-   \[
-   E[\hat{\theta_{2}}] = E\left[\frac{X_{1}^{2} + X_{2}^{2}}{2}\right]
-  \]
-  \[
-   = \frac{1}{2} \times E[X_{1}^{2} + X_{2}^{2}]
-  \]
-  \[
-   = \frac{1}{2} \times (E[X_{1}^{2}] + E[X_{2}^{2}])
-  \]
-  \[
-   = \frac{1}{2} \times (E[X_{1}^{2}] - E^{2}[X_{1}] + E^{2}[X_{1}] + E[X_{2}^{2}] - E^{2}[X_{2}] + E^{2}[X_{2}])
-  \]
-  \[
-   = \frac{1}{2} \times (\sigma^{2} + E^{2}[X_{1}] + \sigma^{2} + E^{2}[X_{2}])
-  \]
-  \[
-   = \frac{1}{2} \times (\sigma^{2} + \mu^{2} + \sigma^{2} + \mu^{2})
-  \]
-  \[
-   = \frac{1}{2} \times (2 *\sigma^{2} + 2 * \mu^{2})
-  \]
-  \[
-   = \sigma^{2} + \mu^{2}
-  \]
+  Calcul du biais du paramètre $\widehat{\theta_{2}}$ donné par l'équation \ref{para2}:
+  \begin{align*}
+	E[\widehat{\theta_{2}}] &= E\left[\frac{X_{1}^{2} + X_{2}^{2}}{2}\right] \\
+	&= \frac{1}{2} \times E[X_{1}^{2} + X_{2}^{2}] \\
+	&= \frac{1}{2} \times (E[X_{1}^{2}] + E[X_{2}^{2}]) \\
+	&= \frac{1}{2} \times (E[X_{1}^{2}] - E^{2}[X_{1}] + E^{2}[X_{1}] + E[X_{2}^{2}] - E^{2}[X_{2}] + E^{2}[X_{2}]) \\
+	&= \frac{1}{2} \times (\sigma^{2} + E^{2}[X_{1}] + \sigma^{2} + E^{2}[X_{2}]) \\
+	&= \frac{1}{2} \times (\sigma^{2} + \mu^{2} + \sigma^{2} + \mu^{2}) \\
+	&= \frac{1}{2} \times (2 \;\sigma^{2} + 2 \;\mu^{2}) \\
+	&= \sigma^{2} + \mu^{2}
+  \end{align*}
 
   Le biais est donc $\sigma^{2}$
   \bigskip
 
-  Calcul du biais du paramètre $\hat{\theta_{1}}$ :
-
-  \[
-   E[\hat{\theta_{1}}] = E[X_{1} X_{2}]
-  \]
-  \[
-   = E[X_{1}] \times E[X_{2}] + \textrm{Cov}[X_{1} X_{2}]
-  \]
+  Calcul du biais du paramètre $\widehat{\theta_{3}}$ donné par l'équation \ref{para3}:
+	\begin{align*}
+		E[\widehat{\theta_{3}}] &= E[X_{1} X_{2}] \\
+		&= E[X_{1}] \times E[X_{2}] + \textrm{Cov}[X_{1} X_{2}]
+	\end{align*}
 
   Puisque les deux observations sont indépendantes, la corrélation vaut zéro.
   \[
-   = \mu^{2}
+   E[\widehat{\theta_{3}}] = \mu^{2}
   \]
 
   Cet estimateur est sans biais.
@@ -119,7 +76,9 @@ Un agriculteur possède un champ carré de longueur $\mu$, dont il désire estim
 
 \section{}
 
-  Un chercheur étudie l'effet d'un raccourcisseur de paille sur les céréales. Un raccourcisseur de paille est une molécule, fort utilisée en agriculture, qui agit sur la croissance de la plante afin de limiter son développement en hauteur. Dans une expérience, il étudie la différence entre la hauteur des plantes réparties entre 2 groupes. Le premier groupe n'est pas traité et sert de témoin. Le second groupe est traité à l'aide du produit. A la fin de la période de croissance, le chercheur a mesuré la hauteur (en mètres) de quelques plantes choisies au hasard dans chaque groupe. Voici ses résultats : \bigskip
+  Un chercheur étudie l'effet d'un raccourcisseur de paille sur les céréales. Un raccourcisseur de paille est une molécule, fort utilisée en agriculture, qui agit sur la croissance de la plante afin de limiter son développement en hauteur. Dans une expérience, il étudie la différence entre la hauteur des plantes réparties entre 2 groupes. Le premier groupe n'est pas traité et sert de témoin. Le second groupe est traité à l'aide du produit. A la fin de la période de croissance, le chercheur a mesuré la hauteur (en mètres) de quelques plantes choisies au hasard dans chaque groupe. \\
+  
+  Voici ses résultats :
 
   \begin{center}
   \begin{tabular}{@{}lcccccccc@{}}
@@ -144,30 +103,28 @@ Un agriculteur possède un champ carré de longueur $\mu$, dont il désire estim
 
 \begin{solution}
     \begin{enumerate}
-  \item Pour la hauteur moyenne dans un groupe, on est dans le cas où on cherche une moyenne avec une variance inconnue.
-
+  	\item Pour la hauteur moyenne dans un groupe, on est dans le cas où on cherche une moyenne avec une variance inconnue.
+	
+	Notre intervalle de confiance s'écrit comme suit : 
   \[
-   \mu \in \left[\overline{X} \pm t^{(n-1)}_{1-\alpha/2} \times \sqrt{\frac{s^{2}}{n}}\right]
+   \mu \in \left[\overline{X} \pm t^{(n-1)}_{1-\alpha/2} \times \sqrt{\frac{S^{2}}{n}}\right]
   \]
-
+  Nous avons donc besoin de la moyenne et de la variance expérimentale :
+  \begin{multicols}{2}
+	\begin{align*}
+		\overline{X} &= \frac{1}{n} \sum_{t=1}^{N} X_{i} \\
+		&= \frac{1}{8} \times 10,66 = 1,3325
+	\end{align*}
+	\begin{align*}
+		S^{2} &= \frac{1}{(n-1)} \times \sum_{t=1}^{N} {\left(X_{i} - \overline{X}\right)}^{2} \\
+		&= \frac{1}{7} \times 0,16875 = 0,024
+	\end{align*}
+  \end{multicols}
   \[
-   \overline{X} = \frac{1}{n} \sum_{t=1}^{N} X_{i}
-  \]
-  \[
-   = \frac{1}{8} \times 10,66 = 1,3325
-  \]
-
-  \[
-   s^{2} = \frac{1}{(n-1)} \times \sum_{t=1}^{N} {\left(X_{i} - \overline{X}\right)}^{2}
-  \]
-  \[
-   s^{2} = \frac{1}{7} \times 0,16875 = 0,024
-  \]
-  \[
-   t^{7}_{0,975} = 2,365
+   st^{7}_{0,975} = 2,365
   \]
   \[
-   \mu \in \left[1,3325 \pm 2,365 \times \sqrt{\frac{0,024}{8}}\right]
+   \mu \in \left[1,3325 \ \pm \ 2,365 \times \sqrt{\frac{0,024}{8}}\right]
   \]
   \[
    \mu \in \left[1,203;1,462\right]
@@ -184,7 +141,7 @@ Un agriculteur possède un champ carré de longueur $\mu$, dont il désire estim
 
 
   On calcule que,
-
+ 
 	\[
 	n_{1} = n_{2} = 8,\ \overline{X}_{1} = 1,33625,\ \overline{X}_{2} = 1,14625
 	\]
@@ -207,7 +164,7 @@ Un agriculteur possède un champ carré de longueur $\mu$, dont il désire estim
 	F_{th} = F_{0,95}(7,7) = 3,787
 	\]
 	
-	La statistique $F_{obs}$ étant considéré comme étant dans la région critique si jamais $F_{obs} \ge F_{th}$ est vérifié, nous remarquons ici que :
+	La statistique $F_{obs}$ étant considérée comme étant dans la région critique si jamais $F_{obs} \ge F_{th}$ est vérifié, nous remarquons ici que :
 	
 	\[
 	1,751 < 3,787
@@ -224,13 +181,13 @@ Un agriculteur possède un champ carré de longueur $\mu$, dont il désire estim
 		H_1 &\equiv \mu_1 > \mu_2 &\Leftrightarrow& &\mu_1 - \mu_2 &> d_0
 	\end{align*}
 
-	Comme nous ne connaissons pas la variance $\sigma^2$, nous allons utiliser la loi de \textbf{Student} afin de calculer notre statistique $T$ tel que :
+	Comme nous ne connaissons pas la variance $\sigma^2$, nous allons utiliser la loi de \textbf{Student} afin de calculer notre statistique $T$ telle que :
 	
 	\[
 	T_{obs} = \frac{\overline{X}_1 - \overline{X}_2 - d_0}{\sqrt{S^{2}_P (\frac{1}{n_1} + \frac{1}{n_2})}}
 	\]
 	
-	Pour calculer $S^{2}_P$, nous utilisons la formule de combinaison de variance,
+	Pour calculer $S^{2}_P$, nous utilisons la formule de combinaison de variances,
 	
 	\[
 	S^{2}_{Pooled} = \frac{(n_1 - 1) S^{2}_1 + (n_2 - 1) S^{2}_2}{n_1 + n_2 - 2}
@@ -249,7 +206,7 @@ Un agriculteur possède un champ carré de longueur $\mu$, dont il désire estim
 	Nous pouvons maintenant calculer la statistique théorique pour une valeur de confiance $\alpha = 0,05$, c'est-à-dire le quantile d'ordre $1-\alpha$. 
 	
 	\[
-	T_{th} = St^{0,95}_{14} = 1,761
+	T_{th} = st^{0,95}_{14} = 1,761
 	\]
 	
 	La région critique où on doit rejeter l'hypothèse nulle étant considérée comme étant $T_{obs} \geq T_{th}$, nous remarquons ici que :
@@ -263,7 +220,7 @@ Un agriculteur possède un champ carré de longueur $\mu$, dont il désire estim
 	Si nous effectuons un deuxième test avec cette fois-ci une valeur de confiance de $\alpha = 0,01$, nous pouvons remarquer que :
 	
 	\[
-	T_{th2} = St^{0,99}_{14} = 2,624
+	T_{th2} = st^{0,99}_{14} = 2,624
 	\]
 	Et donc,
 	\[
@@ -355,7 +312,7 @@ Un agriculteur possède un champ carré de longueur $\mu$, dont il désire estim
 	\end{bmatrix}
 	\]
 
-	On calcule, $\overline{X} = 1,0375$, $\overline{Y} = 0,30125$, $\sum_{i=1}^{8} {(X_{i}-\overline{X})}^{2} = 2,17875$ et $\sum_{i=1}^{8} (X_{i}-\overline{X})(Y_{i}-\overline{Y}) = 0,76559$
+	On calcule, $\overline{X} = 1,0375\,$, $\overline{Y} = 0,30125\,$, $\sum_{i=1}^{8} {(X_{i}-\overline{X})}^{2} = 2,17875$ et $\sum_{i=1}^{8} (X_{i}-\overline{X})(Y_{i}-\overline{Y}) = 0,76559$
 	
 	Nous pouvons maintenant calculer les estimations de $\widehat{b}$,
 	\[
@@ -369,17 +326,17 @@ Un agriculteur possède un champ carré de longueur $\mu$, dont il désire estim
 	\[
 	S^{2} = \frac{\sum_{i=1}^{8} {(Y_{i}-\overline{Y})}^{2}}{n-2} = 0,0572
 	\]
-	Dans la table de distribution de \textbf{Student} de n-2 degrés de liberté, nous trouvons que $t_{0,975}^6=1,94318$.
+	Dans la table de distribution de \textbf{Student} de $n-2$ degrés de liberté, nous trouvons que $st_{0,975}^6=1,94318$.
 	Et l'intervalle de confiance pour la pente ($b$) vaut
 	\[
 	\begin{bmatrix}
-    \widehat{b}\pm t_{0,95;n-2}\sqrt{\frac{S^{2}}{\sum_{i=1}^{n} {(X_{i}-\overline{X})}^{2}}}
+    \widehat{b}\pm st_{0,95;n-2}\sqrt{\frac{S^{2}}{\sum_{i=1}^{n} {(X_{i}-\overline{X})}^{2}}}
 	\end{bmatrix}
 	\]
 	Donc,
 	\[
 	\begin{bmatrix}
-    -0,045082; 0,7478621
+    -0,045082\,;\, 0,7478621
 	\end{bmatrix}
 	\]
 
@@ -391,10 +348,13 @@ Un agriculteur possède un champ carré de longueur $\mu$, dont il désire estim
 	H_{1}: b & \neq & 0
     \end{eqnarray*}
 
-	La statistique de test est $T = \frac{\widehat{b}}{\sqrt{\frac{S^{2}}{\sum_{i=1}^{n} {(X_{i}-\overline{X})}^{2}}}}$
-	avec laquelle nous pouvons calculer la valeur observée de cette statistique valant $T_{obs}=2,168678$
+	La statistique de test s'écrit 
+	$$
+	T = \frac{\widehat{b}}{\sqrt{\frac{S^{2}}{\sum_{i=1}^{n} {(X_{i}-\overline{X})}^{2}}}}
+	$$
+	avec laquelle nous pouvons calculer la valeur observée de cette statistique valant $T_{obs} = 2,168678$\\
 
-	Or, celle-ci est supérieur à $T_{th} = t_{0,975}^6 = 2,446912$ que nous avions trouvé précédemment.\\
+	Or, celle-ci est supérieure à $T_{th} = t_{0,975}^6 = 2,446912$ que nous avions trouvé précédemment.\\
 	Comme $T_{th} > T_{obs}$, la statistique ne se trouve pas dans la région critique, et nous ne pouvons donc pas rejeter l'hypothèse nulle.
 
 	\item

--- a/src/q5/stat-BIR1304/exam/2011/Septembre/All/stat-BIR1304-exam-2011-Septembre-All.tex
+++ b/src/q5/stat-BIR1304/exam/2011/Septembre/All/stat-BIR1304-exam-2011-Septembre-All.tex
@@ -4,7 +4,7 @@
 \usepackage{csquotes}
 
 \hypertitle{Probabilités et statistiques II}{5}{BIR}{1304}{2011}{Août}{All}
-{Florian Thuin\and Paul-Henri Callewaert}
+{Florian Thuin\and Paul-Henri Callewaert \and François Duchêne}
 {Patrick Bogaert}
 
 \section{}
@@ -176,49 +176,101 @@ Un agriculteur possède un champ carré de longueur $\mu$, dont il désire estim
   \item Pour que la variance de la hauteur des plantes traitées soit considérée identique à celle des plantes non-traitées, il faut que, $H_{0} : \frac{\sigma_{2}^{2}}{\sigma_{1}^{2}} = \gamma_{0}$ où $\gamma_{0} = 1$ dans notre cas.
 
   Considérons le problème de test comme étant,
+  
+  \begin{align*}
+  	 H_{0} &\equiv \frac{\sigma_{2}^{2}}{\sigma_{1}^{2}} = \gamma_{0} = 1 \\
+  	 H_{1} &\equiv \frac{\sigma_{2}^{2}}{\sigma_{1}^{2}} \neq \gamma_{0}
+  \end{align*}
 
-  \[
-   H_{0} \equiv \frac{\sigma_{2}^{2}}{\sigma_{1}^{2}} = 1
-   \]
-   \[
-   H_{1} \equiv \frac{\sigma_{2}^{2}}{\sigma_{1}^{2}} \neq 1
-  \]
 
   On calcule que,
 
 	\[
-	n_{1} = n_{2} = 8, \overline{X}_{1} = 1,3325, \overline{X}_{2} = 1,14625
+	n_{1} = n_{2} = 8,\ \overline{X}_{1} = 1,33625,\ \overline{X}_{2} = 1,14625
 	\]
 	\[
-	S^{2}_{1} = \frac{1}{(n-1)} \times \sum_{t=1}^{N} {\left(X_{i} - \overline{X}\right)}^{2} = \frac{1}{7} \times 0,16875 = 0,0241
+	S^{2}_{1} = \frac{1}{(n-1)} \times \sum_{t=1}^{N} {\left(X_{i} - \overline{X}\right)}^{2} = \frac{1}{7} \times 0,16875 = 0,02411
 	\]
 	\[
-	S^{2}_{2} = \frac{1}{(n-1)} \times \sum_{t=1}^{N} {\left(X_{i} - \overline{X}\right)}^{2} = \frac{1}{7} \times 0,0313171 = 0,00447388
+	S^{2}_{2} = \frac{1}{(n-1)} \times \sum_{t=1}^{N} {\left(X_{i} - \overline{X}\right)}^{2} = \frac{1}{7} \times 0,0963875 = 0,013769
 	\]
 
 	On calcule la valeur observée de la statistique :
 
 	\[
-	F_{obs} = \frac{S^{2}_{1}}{S^{2}_{2}} = \frac{0,0241}{0,00447388} = 5,38788
+	F_{obs} = \frac{S^{2}_{1}}{S^{2}_{2}} = \frac{0,02411}{0,013769} = 1,75103
 	\]
 
-	Nous remarquons que $S^{2}_{1}>S^{2}_{2}$. Nous allons donc chercher, pour $\alpha=0,05$, le quantile d'ordre $1-\alpha$ dans la distribution de Fisher-Snedecor de paramètre (7, 7),
+	Nous remarquons que $S^{2}_{1}>S^{2}_{2}$. Nous allons donc chercher, pour $\alpha=0,05$, le quantile d'ordre $1-\alpha$ dans la distribution de \textbf{Fisher-Snedecor} de paramètre (7, 7),
 
 	\[
-	F_{0,95}(7,7) = 3,787 < 5,38788
+	F_{th} = F_{0,95}(7,7) = 3,787
 	\]
-
-	Il y a donc rejet de l'hypothèse de $H_{0}$ pour $\alpha=0,05$. Les variances ne sont donc pas considérées comme égales.
-	\newline
-	Imaginons maintenant que $\alpha = 0,01$, nous obtenons,
-
-    \[
-	F_{0,99}(7,7) = 6,993 > 5,38788.
+	
+	La statistique $F_{obs}$ étant considéré comme étant dans la région critique si jamais $F_{obs} \ge F_{th}$ est vérifié, nous remarquons ici que :
+	
+	\[
+	1,751 < 3,787
 	\]
+	
+	Il n'y a donc pas rejet de l'hypothèse $H_{0}$ pour $\alpha=0,05$. Les variances pourraient être considérées égales. On s'attend en effet à ce que $H_{0}$ soit vraie lorsque la valeur de $F_{obs}$ s'approche de 1.
 
-	Dans ce dernier cas, les variances sont considérées comme étant égales et les hypothèses du test sont respectées.
+	\item Comme nous pouvons considérer la possibilité que les variances sont peut-être égales, nous pouvons effectuer un second test d'hypothèse sur les moyennes des deux échantillons. Nous supposons alors que $\sigma_{1}^2 = \sigma_{2}^2 = \sigma^2$.
+	
+	Considérons le test d'hypothèse suivant,
+	
+	\begin{align*}
+		H_0 &\equiv \mu_1 = \mu_2 &\Leftrightarrow& &\mu_1 - \mu_2 &= d_0 = 0\\
+		H_1 &\equiv \mu_1 > \mu_2 &\Leftrightarrow& &\mu_1 - \mu_2 &> d_0
+	\end{align*}
 
-	\item Les variances ne sont pas considérées comme égales et l'hypothèse est rejetée. On ne peut donc pas affirmer que le traitement induit une diminution de la taille des plantes.
+	Comme nous ne connaissons pas la variance $\sigma^2$, nous allons utiliser la loi de \textbf{Student} afin de calculer notre statistique $T$ tel que :
+	
+	\[
+	T_{obs} = \frac{\overline{X}_1 - \overline{X}_2 - d_0}{\sqrt{S^{2}_P (\frac{1}{n_1} + \frac{1}{n_2})}}
+	\]
+	
+	Pour calculer $S^{2}_P$, nous utilisons la formule de combinaison de variance,
+	
+	\[
+	S^{2}_{Pooled} = \frac{(n_1 - 1) S^{2}_1 + (n_2 - 1) S^{2}_2}{n_1 + n_2 - 2}
+	\]
+	
+	\[
+	S^{2}_P = \frac{(8 - 1) \times 0,02411 + (8 - 1) \times 0,013769}{14} = \frac{0,265153}{0,01894} = 0,01894
+	\]
+	
+	Maintenant que nous avons notre variance combinée, nous pouvons calculer notre statistique $T$ :
+	
+	\[
+	T_{obs} = \frac{1,33625-1,14625}{\sqrt{0,01894 \times (\frac{1}{8} + \frac{1}{8})}} = \frac{0,19}{0,06881} = 2,7612
+	\]
+	
+	Nous pouvons maintenant calculer la statistique théorique pour une valeur de confiance $\alpha = 0,05$, c'est-à-dire le quantile d'ordre $1-\alpha$. 
+	
+	\[
+	T_{th} = St^{0,95}_{14} = 1,761
+	\]
+	
+	La région critique où on doit rejeter l'hypothèse nulle étant considérée comme étant $T_{obs} \geq T_{th}$, nous remarquons ici que :
+	
+	\[
+	2,7612 > 1,761
+	\]
+	
+	Nous pouvons donc rejeter l'hypothèse nulle.
+	
+	Si nous effectuons un deuxième test avec cette fois-ci une valeur de confiance de $\alpha = 0,01$, nous pouvons remarquer que :
+	
+	\[
+	T_{th2} = St^{0,99}_{14} = 2,624
+	\]
+	Et donc,
+	\[
+	2,7612 > 2,624
+	\]
+	
+	L'hypothèse nulle peut à nouveau être rejetée. Nous en concluons que le traitement a un effet significatif sur la diminution de la taille des plantes.
     \end{enumerate}
 
 \end{solution}
@@ -291,7 +343,7 @@ Un agriculteur possède un champ carré de longueur $\mu$, dont il désire estim
 \]
 
 	On calcule, $\overline{X} = 1,0375$, $\overline{Y} = 0,30125$, $\sum_{i=1}^{8} {(X_{i}-\overline{X})}^{2} = 2,17875$ et $\sum_{i=1}^{8} (X_{i}-\overline{X})(Y_{i}-\overline{Y}) = 0,76559$
-	Nous pouvons manitenant calculer,
+	Nous pouvons maintenant calculer,
 	\[
 	\widehat{\beta} = \frac{\sum_{i=1}^{8} (X_{i}-\overline{X})(Y_{i}-\overline{Y})}{\sum_{i=1}^{8} {(X_{i}-\overline{X})}^{2}} = \frac{0,76559}{2,17875} = 0,35139
 	\]

--- a/src/q5/stat-BIR1304/exam/2011/Septembre/All/stat-BIR1304-exam-2011-Septembre-All.tex
+++ b/src/q5/stat-BIR1304/exam/2011/Septembre/All/stat-BIR1304-exam-2011-Septembre-All.tex
@@ -300,72 +300,86 @@ Un agriculteur possède un champ carré de longueur $\mu$, dont il désire estim
   \end{enumerate}
 
 \begin{solution}
-  On sait que la chaleur (variable Y) est dépendante de la fréquence (variable X). On sait également que le modèle est linéaire.
+  On sait que la chaleur (variable $Y$) est dépendante de la fréquence (variable $X$). On sait également que le modèle est linéaire.
+  
+  Il s'agit donc d'une régression \emph{simple}, pouvant s'écrire tel que
+  
+  \[
+  Y = a + b X + \epsilon
+  \]
+  
+  avec $a$ et $b$ les deux paramètres de cette régression et $\epsilon$ l'erreur.
 
   \begin{enumerate}
 
   \item Le modèle peut être écrit sous forme matricielle
-
+  
+  De façon simpliste :
   \[
-   E[T] = E\left[\sum_{i=1}^{n} a_{i} X_{i}\right] = \sum_{i=1}^{n} a_{i} \times \underbrace{E[X_{i}]}_{\mu} = \underbrace{\sum_{i=1}^{n} a_{i}}_{1} \times \mu = \mu
+  Y = \beta \times X
   \]
+  %%% Je vois pas beaucoup l'intérêt de la ligne suivante, s'agit il
+  %\[
+   %E[T] = E\left[\sum_{i=1}^{n} a_{i} X_{i}\right] = \sum_{i=1}^{n} a_{i} \times \underbrace{E[X_{i}]}_{\mu} = \underbrace{\sum_{i=1}^{n} a_{i}}_{1} \times \mu = \mu
+  %\]
+	De façon plus détaillée :
+	\[
+	\begin{bmatrix}
+	    n       & \sum_{i=1}^{n} X_{i} \\
+	    \sum_{i=1}^{n} X_{i} & \sum_{i=1}^{n} X_{i}^{2} \\
+	\end{bmatrix}
+	\times \begin{bmatrix}
+	    a \\
+	    b \\
+	\end{bmatrix}
+	=
+	\begin{bmatrix}
+	    \sum_{i=1}^{n} Y_{i} \\
+	    \sum_{i=1}^{n} X_{i} Y_{i} \\
+	\end{bmatrix}
+	\]
 
 	\[
 	\begin{bmatrix}
-    n       & \sum_{i=1}^{n} X_{i} \\
-    \sum_{i=1}^{n} X_{i} & \sum_{i=1}^{n} X_{i}^{2} \\
-\end{bmatrix}
-\times \begin{bmatrix}
-    \alpha \\
-    \beta \\
-\end{bmatrix}
-=
-\begin{bmatrix}
-    \sum_{i=1}^{n} Y_{i} \\
-    \sum_{i=1}^{n} X_{i} Y_{i} \\
-\end{bmatrix}
-\]
-
-\[
+	    8       & 8,3 \\
+	    8,3 & 10,79 \\
+	\end{bmatrix}
+	\times \begin{bmatrix}
+	    a \\
+	    b \\
+	\end{bmatrix}
+	=
 	\begin{bmatrix}
-    8       & 8,3 \\
-    8,3 & 10,79 \\
-\end{bmatrix}
-\times \begin{bmatrix}
-    \alpha \\
-    \beta \\
-\end{bmatrix}
-=
-\begin{bmatrix}
-    2,41 \\
-    3,282 \\
-\end{bmatrix}
-\]
+	    2,41 \\
+	    3,282 \\
+	\end{bmatrix}
+	\]
 
 	On calcule, $\overline{X} = 1,0375$, $\overline{Y} = 0,30125$, $\sum_{i=1}^{8} {(X_{i}-\overline{X})}^{2} = 2,17875$ et $\sum_{i=1}^{8} (X_{i}-\overline{X})(Y_{i}-\overline{Y}) = 0,76559$
-	Nous pouvons maintenant calculer,
+	
+	Nous pouvons maintenant calculer les estimations de $\widehat{b}$,
 	\[
-	\widehat{\beta} = \frac{\sum_{i=1}^{8} (X_{i}-\overline{X})(Y_{i}-\overline{Y})}{\sum_{i=1}^{8} {(X_{i}-\overline{X})}^{2}} = \frac{0,76559}{2,17875} = 0,35139
+	\widehat{b} = \frac{\sum_{i=1}^{8} (X_{i}-\overline{X})(Y_{i}-\overline{Y})}{\sum_{i=1}^{8} {(X_{i}-\overline{X})}^{2}} = \frac{0,76559}{2,17875} = 0,35139
 	\]
 	\[
-	\widehat{\alpha} = \overline{Y}-\widehat{\beta} \times \overline{X} = -0,06332
+	\widehat{a} = \overline{Y}-\widehat{b} \times \overline{X} = -0,06332
 	\]
 
 	\item Nous calculons que
 	\[
 	S^{2} = \frac{\sum_{i=1}^{8} {(Y_{i}-\overline{Y})}^{2}}{n-2} = 0,0572
 	\]
-	Dans la table de distribution de Student de n-2 degrés de liberté, nous trouvons que $t_{0,95}=1,943$.
-	Et l'intervalle de confiance pour la pente ($\beta$) vaut
+	Dans la table de distribution de \textbf{Student} de n-2 degrés de liberté, nous trouvons que $t_{0,975}^6=1,94318$.
+	Et l'intervalle de confiance pour la pente ($b$) vaut
 	\[
 	\begin{bmatrix}
-    \widehat{\beta}\pm t_{0,95;n-2}\sqrt{\frac{S^{2}}{\sum_{i=1}^{n} {(X_{i}-\overline{X})}^{2}}}
+    \widehat{b}\pm t_{0,95;n-2}\sqrt{\frac{S^{2}}{\sum_{i=1}^{n} {(X_{i}-\overline{X})}^{2}}}
 	\end{bmatrix}
 	\]
 	Donc,
 	\[
 	\begin{bmatrix}
-    0,0366, 0,6662
+    -0,045082; 0,7478621
 	\end{bmatrix}
 	\]
 
@@ -373,15 +387,15 @@ Un agriculteur possède un champ carré de longueur $\mu$, dont il désire estim
 	On s'intéresse au problème de test défini par :
 
 	\begin{eqnarray*}
-	H_{0}: \beta & = & 0 \\
-	H_{1}: \beta & \neq & 0
+	H_{0}: b & = & 0 \\
+	H_{1}: b & \neq & 0
     \end{eqnarray*}
 
-	La statistique de test est $T = \frac{\widehat{\beta}}{\sqrt{\frac{S^{2}}{\sum_{i=1}^{n} {(X_{i}-\overline{X})}^{2}}}}$
-	avec laquelle nous pouvons calculer la valeur observée de cette statistique valant $T_{obs}=2,1687$
+	La statistique de test est $T = \frac{\widehat{b}}{\sqrt{\frac{S^{2}}{\sum_{i=1}^{n} {(X_{i}-\overline{X})}^{2}}}}$
+	avec laquelle nous pouvons calculer la valeur observée de cette statistique valant $T_{obs}=2,168678$
 
-	Or, celle-ci est supérieur à $t_{0,95;6} = 1,943$ que nous avions trouvé précédemment.\\
-	Nous pouvons donc conclure qu'il y a un rejet de l'hypothèse nulle pour 0,05. L'échauffement des cellules n'est donc pas lié à la fréquence.
+	Or, celle-ci est supérieur à $T_{th} = t_{0,975}^6 = 2,446912$ que nous avions trouvé précédemment.\\
+	Comme $T_{th} > T_{obs}$, la statistique ne se trouve pas dans la région critique, et nous ne pouvons donc pas rejeter l'hypothèse nulle.
 
 	\item
 	!!! Ceci est une ébauche de la sous-question 4 !!!


### PR DESCRIPTION
J'ai trouvé plusieurs erreurs dans la correction de l'examen de 2011.
Voici mes propositions de correction :
- Question 2 : Dans le point deux, la deuxième variance expérimentale est mal calculée (bête faute de calcul). Ce qui entraine une réponse complètement différente du point 3, puisqu'on ne rejette pas H0 dans le point 2. Il faut donc faire un nouveau test d'hypothèse pour le point 3.
- Question 3 : Ajouté des précisions dans le début de la résolution de la première question. De nouveau trouvé des fautes dans le point 2 et donc dans le point 4 avec une faute dans le degré de confiance utilisé (on utilise 0,95 alors qu'il faudrait utiliser 0,975 puisqu'on calcule une intervalle de confiance qui est par définition bilatéral).
- Toujours pour la question 3, j'ai changé l'utilisation des beta et alpha avec a et b pour éviter la confusion avec *Beta* qui représente les deux paramètres de la régression en même temps (NDLR. d'accord ça vient du syllabus écrit (ou pas) par le prof, mais ça n'enlève en rien du fait que c'est mal écrit et mal foutu et qu'on est pas forcément obligé de refaire les mêmes erreurs dans les corrections)