### PR TITLE
[LFSAB1105] Correction formulaire 2

### DIFF
--- a/src/q5/stat-FSAB1105/formulaire2/stat-FSAB1105-formulaire.tex
+++ b/src/q5/stat-FSAB1105/formulaire2/stat-FSAB1105-formulaire.tex
@@ -558,7 +558,7 @@ $CI^t=\left[\frac{(n-1)S^2}{\mathcal{X}^2_{n-1,\alpha/2}},\frac{(n-1)S^2}{\mathc
 \begin{itemize}
 \item $X_{ji}\sim_{iid}\mathcal{N}(\mu_j,\sigma_j^2)$ or $\approx$ by CLT/MLE \\ \& known $\sigma_i$ or $S_{n,i} (n_i>30)$ \\
 $Z=\frac{(\bar{X}_1-\bar{X}_2)-(\mu_1-\mu_2)}{\sqrt{\frac{\sigma_1^2}{n_1}+\frac{\sigma_2^2}{n_2}}}\sim \mathcal{N}(0,1)$\\ 
-$CI=(\bar{X}_1-\bar{X}_2)\pm z_{a/2}\sqrt{\frac{\sigma_1}{n_1}+\frac{\sigma_2}{n_2}}$
+$CI=(\bar{X}_1-\bar{X}_2)\pm z_{a/2}\sqrt{\frac{\sigma_1^2}{n_1}+\frac{\sigma_2^2}{n_2}}$
 \item $X_{ji}\sim_{iid}\mathcal{N}(\mu_j,\sigma^2)$ \& same unknown $\sigma_j$ ($n<30$): \\
 $Z=\frac{(\bar{X}_1-\bar{X}_2)-(\mu_1-\mu_2)}{S_p\sqrt{1/n_1+1/n_2}}\sim t_{n_1+n_2-2}$\\ 
 $CI=(\bar{X}_1-\bar{X}_2)\pm t_{n_1+n_2-2,\alpha/2}S_p\sqrt{1/n_1+1/n_2}$\\

--- a/src/q5/stat-FSAB1105/formulaire2/stat-FSAB1105-formulaire.tex
+++ b/src/q5/stat-FSAB1105/formulaire2/stat-FSAB1105-formulaire.tex
@@ -7,6 +7,7 @@
 \usepackage{color}
 \usepackage{array}
 \usepackage{amsmath, amsfonts, amssymb}
+\usepackage{esdiff}  %pour la commande \diff{~}{~}
 \usepackage{multirow}
 \usepackage{tabu,enumerate,tabularx}
 \newcounter{row}
@@ -392,12 +393,13 @@ $P(Y\leq y)=\sum_{x:g(x)\leq y}P(X=x)$
 \item $X$ contin. r.v. with domain $I$ \& density $f_X(x)$
 \item $Y=g(X)$ with $g$ differentiable  \& strict. monot. on $I$
 \end{itemize}
-$f_Y(y)=\left.\frac{f_X(x)}{|g'(x)|} \right|_{x=g^{-1}(y)}$, for $ y \in g(I)$\\
-Linear transf.: If $Y=aX+b$, then $f_Y(y)=\frac{1}{|b|}f_X \left( \frac{y-a}{b}\right)$
+$f_Y(y)=f_X(g^{-1}(y))|\diff{g^{-1}(y)}{y}| $, for $ y \in g(I)$\\
+Linear transf.: If $Y=a+bX$, then $f_Y(y)=\frac{1}{|b|}f_X \left( \frac{y-a}{b}\right)$
 \paragraph{Not monotonic Transformation} (piecewise inv.) ~~\\
-$f_Y(y)=\sum_{x\in g^{-1}(y)} \frac{f_X(x)}{|g'(x)|} $, where $ g^{-1}(y)= \{x:g(x)=y\}$
+$f_Y(y)=\sum_{x\in g^{-1}(y)} f_X(g^{-1}(y))|\diff{g^{-1}(y)}{y}| $,\\
+where $ g^{-1}(y)= \{x:g(x)=y\}$
 \paragraph{One-to-one transformations} $Y_i=g_i(X_1,X_2)$\\
-$f_\textbf{Y}(\textbf{y})=\left.\frac{f_\textbf{X}(\textbf{x})}{|Jac_g(\textbf{x})|} \right|_{\textbf{x}=g^{-1}(\textbf{y})}$
+$f_\textbf{Y}(\textbf{y})=f_\textbf{X}(g^{-1}(\textbf{y}))|Jac(g^{-1}(\textbf{y}))|$
 \paragraph{Two-to-one transformations} $Z=g(X,Y)$\\
 $F_Z(z)=P(Z\leq z)= \iint I(g(x,y)\leq z)f(x,y)dxdy$
 \begin{enumerate}


### PR DESCRIPTION
Dans la section «Functions of Random Variables», le paragraphe
«Strictly monotonic transformation» ainsi que le deux suivants étaient
faux à cause d’une confusion entre l’inverse d’une fonction et sa
réciproque.

Dans la section «Confidence Interval» paragraphe «(Asymptotically valid)
CI for u1-u2» la variance était confondue avec l’écart-type.