### PR TITLE
Correction de la commande fdpart{f}{x}{y}

### DIFF
--- a/src/eplcommon.sty
+++ b/src/eplcommon.sty
@@ -93,7 +93,7 @@
 % It has never been easier to write derivatives !
 \newcommand{\fpart}[2]{\dfrac{\partial #1}{\partial #2}}
 \newcommand{\ffpart}[2]{\dfrac{\partial^2 #1}{\partial #2^2}}
-\newcommand{\fdpart}[3]{d\frac{\partial^2 #1}{\partial #2\partial #3}}
+\newcommand{\fdpart}[3]{\dfrac{\partial^2 #1}{\partial #2\partial #3}}
 \newcommand{\fnpart}[3]{\dfrac{\partial^{#3} #1}{\partial {#2}^{#3}}}
 \newcommand{\fdif}[2]{\dfrac{\dif #1}{\dif #2}}
 \newcommand{\ffdif}[2]{\dfrac{\dif^2 #1}{\dif #2^2}}


### PR DESCRIPTION
Il me semble qu'il y a une petite faute de frappe dans le template, `d\frac` au lieu de `\dfrac`