### PR TITLE
[LELEC1370] voltage sign direction correction

### DIFF
--- a/src/q4/circmes-ELEC1370/exam/2013/Juin/Majeure/circmes-ELEC1370-exam-2013-Juin-Majeure.tex
+++ b/src/q4/circmes-ELEC1370/exam/2013/Juin/Majeure/circmes-ELEC1370-exam-2013-Juin-Majeure.tex
@@ -1,6 +1,6 @@
 \documentclass[fr]{../../../../../../eplexam}
 \usepackage{../../../../../../eplunits}
-\usepackage{circuitikz}
+\usepackage[oldvoltagedirection]{circuitikz}
 \usepackage{pgfplots}
 \usepackage{enumitem}
 \pgfplotsset{compat=newest}

--- a/src/q4/circmes-ELEC1370/exam/2013/Juin/Mineure/circmes-ELEC1370-exam-2013-Juin-Mineure.tex
+++ b/src/q4/circmes-ELEC1370/exam/2013/Juin/Mineure/circmes-ELEC1370-exam-2013-Juin-Mineure.tex
@@ -1,6 +1,6 @@
 \documentclass[fr]{../../../../../../eplexam}
 \usepackage{../../../../../../eplunits}
-\usepackage{circuitikz}
+\usepackage[oldvoltagedirection]{circuitikz}
 \usepackage{pgfplots}
 \usepackage{enumitem}
 \pgfplotsset{compat=newest}

--- a/src/q4/circmes-ELEC1370/exam/2014/Juin/Majeure/circmes-ELEC1370-exam-2014-Juin-Majeure.tex
+++ b/src/q4/circmes-ELEC1370/exam/2014/Juin/Majeure/circmes-ELEC1370-exam-2014-Juin-Majeure.tex
@@ -1,6 +1,6 @@
 \documentclass[fr]{../../../../../../eplexam}
 \usepackage{../../../../../../eplunits}
-\usepackage{circuitikz}
+\usepackage[oldvoltagedirection]{circuitikz}
 \usepackage{pgfplots}
 \usepackage{enumitem}
 \pgfplotsset{compat=newest}

--- a/src/q4/circmes-ELEC1370/exam/2014/Septembre/All/circmes-ELEC1370-exam-2014-Septembre-All.tex
+++ b/src/q4/circmes-ELEC1370/exam/2014/Septembre/All/circmes-ELEC1370-exam-2014-Septembre-All.tex
@@ -1,6 +1,6 @@
 \documentclass[fr]{../../../../../../eplexam}
 \usepackage{../../../../../../eplunits}
-\usepackage{circuitikz}
+\usepackage[oldvoltagedirection]{circuitikz}
 \usepackage{pgfplots}
 \usepackage{enumitem}
 \pgfplotsset{compat=newest}

--- a/src/q4/circmes-ELEC1370/exam/2016/Juin/Majeure/circmes-ELEC1370-exam-2016-Juin-Majeure.tex
+++ b/src/q4/circmes-ELEC1370/exam/2016/Juin/Majeure/circmes-ELEC1370-exam-2016-Juin-Majeure.tex
@@ -1,6 +1,6 @@
 \documentclass[fr]{../../../../../../eplexam}
 \usepackage{../../../../../../eplunits}
-\usepackage{circuitikz}
+\usepackage[oldvoltagedirection]{circuitikz}
 \usepackage{pgfplots}
 \pgfplotsset{compat=newest}
 

--- a/src/q4/circmes-ELEC1370/summary/circmes-ELEC1370-summary.tex
+++ b/src/q4/circmes-ELEC1370/summary/circmes-ELEC1370-summary.tex
@@ -16,7 +16,7 @@
 \usepackage[bottom]{footmisc}
 \usepackage{wrapfig}
 \geometry{hmargin=1.8cm, vmargin=1.8cm}
-\usepackage[american]{circuitikz}
+\usepackage[oldvoltagedirection, american]{circuitikz}
 \usepackage{adjustbox}
 
 \setcounter{tocdepth}{2}

--- a/src/q4/circmes-ELEC1370/test/2017/Mars/All/circmes-ELEC1370-test-2017-Mars-All.tex
+++ b/src/q4/circmes-ELEC1370/test/2017/Mars/All/circmes-ELEC1370-test-2017-Mars-All.tex
@@ -1,6 +1,6 @@
 \documentclass[en]{../../../../../../epltest}
 \usepackage{../../../../../../eplunits}
-\usepackage{circuitikz}
+\usepackage[oldvoltagedirection]{circuitikz}
 \usepackage{steinmetz}
 
 \hypertitle{circmes-ELEC1370}{4}{ELEC}{1370}{2017}{Mars}{All}


### PR DESCRIPTION
\usepackage[oldvoltagedirection]{circuitikz} everywhere in LELEC1370