### PR TITLE
correction definition preuve formelle/informelle

### DIFF
--- a/src/q5/logique-INGI1101/summary/logique-INGI1101-summary.tex
+++ b/src/q5/logique-INGI1101/summary/logique-INGI1101-summary.tex
@@ -360,10 +360,10 @@ mais fait partie du métalangage.
 	qui démontre si une proposition est vraie ou fausse.
 	On distingue les preuves \emph{formelles} et \emph{informelles}.
 	\begin{itemize}
-		\item Une \emph{preuve formelle}
+		\item Une \emph{preuve informelle}
 		est un raisonnement en langage naturel,
 		parfois augmenté avec des notations mathématiques.
-		\item Une \emph{preuve informelle}
+		\item Une \emph{preuve formelle}
 		est un raisonnement mathématique
 		qui formalise le raisonnement déductif.
 	\end{itemize}


### PR DESCRIPTION
Les 2 définition (preuve formelle et preuve informelle) sont inversées dans la synthèse, ca se voit/devine assez facilement, mais ce serait bête que quelqu'un l'étudie dans ce sens (CF Syllabus moodle p25)