### PR TITLE
[INGI1341] Selective repeat buffer size & Char stuffing correction

### DIFF
--- a/src/q5/network-INGI1341/summary/network-INGI1341-summary.tex
+++ b/src/q5/network-INGI1341/summary/network-INGI1341-summary.tex
@@ -219,7 +219,7 @@ The separation of frames is done using \emph{bit stuffing} or \emph{character st
       \item Increases the number of bits transmitted.
     \end{enumerate}
 \item[Character stuffing]: In software it's easier to work with characters.
-We add a DLE (Data Link Escape) character in front of each DLE contained in the data of the frame.
+We add a DLE (Data Link Escape) character after each DLE contained in the data of the frame.
 (The character used as a marker is not printable.)
 Beginning of frame: \textsc{DLE STX},
 end of frame: \textsc{DLE ETX}.
@@ -296,7 +296,7 @@ A \textit{sliding window} is used to manage the buffer of sequence numbers.
 
 Because the Physical Layer will not reorder the frames,
 the maximum window size for Go-Back-N is $\bf 2^n-1$
-and $\bf 2^{n-1}$ for Selective Repeat.
+and $\bf \dfrac{2^n}{2}$ for Selective Repeat.
 (Think when all the acks are lost.)
 
 \paragraph{Reliability} Not all Datalink Services provide a \emph{reliable} service.


### PR DESCRIPTION
In Character stuffing, the DLE is added after each DLE contained in the data of the frame and not in front. Even if in practice this remains equivalent.
(http://beta.computer-networking.info/syllabus/default/principles/reliability.html#the-datalink-layer)

The selective repeat maximum window size is not 2^(n-1) but (2^n)/2 . 
(http://beta.computer-networking.info/syllabus/default/principles/reliability.html#go-back-n-and-selective-repeat)

