### PR TITLE
Update course_link.py after cleaning config.yaml

### DIFF
--- a/course_link.py
+++ b/course_link.py
@@ -10,24 +10,20 @@ import os
 import sys
 import yaml   
             
-def main():
-    # Absolute path to the config file
-    if len(sys.argv) == 3:
-        CONFIG_FILE_NAME = sys.argv[1] + 'src/config.yml' 
-        name = sys.argv[2]
-    else:
-        CONFIG_FILE_NAME = 'src/config.yml' 
-        name = sys.argv[1]
-        
-    with open(CONFIG_FILE_NAME, 'r') as stream:
-        document = yaml.load(stream)
-        stream.close()
-        try:
-            titre = document['clients'][0]['output']['parameters'][0]['parameters'][5]['mapping'][name]
-        except KeyError:
-            titre = name
+# Absolute path to the config file
+if len(sys.argv) == 3:
+    CONFIG_FILE_NAME = sys.argv[1] + 'src/config.yml' 
+    name = sys.argv[2]
+else:
+    CONFIG_FILE_NAME = 'src/config.yml' 
+    name = sys.argv[1]
+    
+with open(CONFIG_FILE_NAME, 'r') as stream:
+    document = yaml.load(stream)
+    stream.close()
+    try:
+        titre = document['name'][name]
+    except KeyError:
+        titre = name
 
-    print(titre.encode('utf-8'))
-            
-if __name__ == "__main__":
-    main()
+print(titre.encode('utf-8'))


### PR DESCRIPTION
Forgot to update this file, the course title is no longer automatically rendered in hypertitle of the newly created docs.