### PR TITLE
Autolin: Fix formula for amplitude of 1st order TF

### DIFF
--- a/src/q6/autolin-INMA1510/summary2/autolin-INMA1510-summary.tex
+++ b/src/q6/autolin-INMA1510/summary2/autolin-INMA1510-summary.tex
@@ -756,7 +756,7 @@ La fonction de transfert du premier ordre type est donnée par
 L'amplitude et la phase de cette fonction de transfert sont
 \begin{equation}
 \begin{array}{rcl}
-	\abs{\Gjw} & = & 20 \log_{10} \abs{\frac{k}{1 + \imagj \tau \omega}} = \frac{k}{1 + \sqrt{\tau^2 \omega^2}}\,, \\
+	\abs{\Gjw} & = & 20 \log_{10} \abs{\frac{k}{1 + \imagj \tau \omega}} = \frac{k}{\sqrt{1 + \tau^2 \omega^2}}\,, \\
 	\angle \Gjw & = & - \arctan(\tau \omega)\,,
 \end{array}
 \end{equation}


### PR DESCRIPTION
The 1 should be inside the square root, as can be seen on the fiches (v. 2019-05-06), section 6.2.1, on p. 11. Closes #807.