### PR TITLE
correction pseudo code exo 1.3.1

### DIFF
--- a/src/q6/calcu-INGI1123/exercises/calcu_tp1.tex
+++ b/src/q6/calcu-INGI1123/exercises/calcu_tp1.tex
@@ -151,9 +151,9 @@ function print_Z()
 	i = 0
 	println(i)
 	while true
+		i+=1
 		println(i)
 		println(-i)
-		i += 1
 	end
 end
 \end{minted}


### PR DESCRIPTION
if we use the previous pseudo code, instead of printing Z (0,1,-1,2,-2,...), we print 3 different 0 values at the beginning (0,0,-0,1,-1,2,-2,...).
Since we already print 0 before thhe loop and we don't want to print -0, the increment of i has to be in the beginning of the loop