### PR TITLE
Uniformize doc link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Les `.pdf` des synthèses et correctifs dans leur dernière version sont disponi
 Ce README donne quelques premières indications
 quant à l'utilisation de ce repository.
 Pour de plus amples informations,
-voir
-le document [How_to_Contribute][doc-url]
+voir le [guide pour les nouveaux contributeurs][doc-url]
 ou le [wiki](https://github.com/Gp2mv3/Syntheses/wiki).
 
 ## Comment contribuer
@@ -27,9 +26,8 @@ en soumettant une issue sur le
 Même pour une simple faute d'orthographe, ça vaut la peine de le signaler.
 
 Vous pouvez aussi directement modifier le code et nous le soumettre
-en utilisant `git`, voir le document
-[How_to_Contribute.pdf](https://www.dropbox.com/s/s48t7iv4n6xotya/How_to_Contribute.pdf?dl=0)
-pour une explication rapide.
+en utilisant `git`; le [guide pour les nouveaux contributeurs][doc-url]
+donne une explication rapide de comment faire cela.
 Pour une explication plus détaillée, lisez la partie *Utilisation linéaire de Git* de
 [ce tutoriel](http://sites.uclouvain.be/SystInfo/notes/Outils/html/git.html)
 écrit par Benoît Legat.


### PR DESCRIPTION
We missed one reference, this is fixed now. Ref #823.