### PR TITLE
Attempt to fix overfull boxes in front page

### DIFF
--- a/src/eplbase.cls
+++ b/src/eplbase.cls
@@ -183,7 +183,7 @@ echo $(git log -1 --pretty=format:\%h "$(basename $(ls *.stderr) .stderr).tex")
    \IfLanguageName{english}{at the }{à l'}%
    EPL (École Polytechnique de Louvain),
    \IfLanguageName{english}{faculty of the }{faculté de l'}%
-   UCL (Université Catholique de Louvain).
+   \hyphenation{Catho-lique}UCL (Université Catholique de Louvain).
    \IfLanguageName{english}
    {It has been written by the aforementioned authors with the help of all other students,
    yours is therefore welcome as well.


### PR DESCRIPTION
Context: compiling the secure elec summary gives an `overfull \hbox` on the title page because of the long name of the professor.
Cause: "Catholique" has no hyphenation set up, so the compiler cannot split the word and it is forced to keep the full word on the line, as putting the word on the next line would result in a bad visual.
Possible resolution: indicate some hyphenation to the compiler for the word "Catholique". Ex: Catho-lique
Problems: it's not really nice to see the name of the university being split up in parts. So maybe we could just tell LaTeX to stop emitting warnings there and accept such overfulls as "fact of life". Or we could try to reformulate the text in the front page so that LaTeX never has to hyphenate the UCL.