### PR TITLE
Make (no)solutions mandatory

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,11 @@
+Notes pour le mandatory solution:
+C'est extrêmement chiant à faire.
+
+Propositions d'améliorations:
+- Redéfinir itemize/enumerate et leur commande \item pour que utiliser cette commande génère un statement, qui attend donc une solution.
+  Si la solution n'est pas trouvée, indiquer dans le .aux qu'on s'attend à la trouver dans un \item correspondant d'un enumerate qui serait contenu dans un env solution.
+- Dans un env solution, ce même environnement checkerait que tous les item trouvent une correspondance, et qu'il n'y en a pas d'autre.
+- Si un \item est directement suivi de sa solution, alors il faut que dans cette solution il n'y ait qu'un seul item.
+- On pourrait imaginer que l'on ne puisse pas mélanger les deux styles : si on trouve un \begin{solution} après un \item dans un enumerate/itemize de statement, alors ce env solution ne peut contenir qu'une seule solution, et chaque \item suivant doit avoir un \begin{solution} qui le suit. Et on ne peut pas avoir de env solution après l'enumerate. Si au contraire on ne trouve qu'un \item après le premier \item, alors on doit ne trouver aucun env solution dans le enumerate, et on doit trouver un enumerate avec le même nombre d'items que l'enumerate de l'énoncé.
+- Pour l'affaire des section/subsection/etc: si on a \section puis \subsection puis env sol, alors on doit rencontrer un \subsection ou un \section avant de rencontrer un nouvel env sol ou un \nosol; on ne peut pas alors rencontrer de \subsubsection par exemple. Donc dès qu'on rencontre un env sol, on ne peut trouver que deux choses : soit un titre de même niveau; soit un titre de niveau supérieur. Dans les deux cas, ceux-ci gèrent comme ils veulent le fait qu'il y ait une solution ou non. Par contre, pour un titre d'un certain niveau, si on rencontre un titre de même niveau ou de niveau supérieur, sans avoir rencontré de solution, alors il y a une erreur.
+

--- a/src/epleval.cls
+++ b/src/epleval.cls
@@ -68,4 +68,20 @@
 
 \RequirePackage[eval]{../../../../../../eplqa}
 
+\RequirePackage{etoolbox}
+
+\AtBeginEnvironment{solution}{\@checksolution}
+
+\ifthenelse{\equal{\Sol}{false}}
+{\renewcommand{\nosolution}{\@checksolution}}
+{}
+
+\apptocmd{\ttl@labelling}{\ifttl@label\def\epleval@sectstr{section}\def\epleval@argi{#1}\ifx\epleval@sectstr\epleval@argi\@checkstatement\else\fi\fi}{\typeout{Success patching \\ttl@labelling}}{\typeout{FAILED PATCHING \\ttl@labelling - Contact repo administrators}}
+
+\AtEndDocument{%
+	\ifboolexpr{togl {eplqa@waitingforsolution} or not togl {eplqa@waitingforstatement}}{%
+		\PackageError{eplqa}{\@checkstatmt@errmsg{end of document}{Fin de document}}{\@help@rtfm}
+	}{}
+}
+
 \endinput

--- a/src/eplqa.sty
+++ b/src/eplqa.sty
@@ -18,14 +18,14 @@
 
 \newcommand{\@help@rtfm}{\IfLanguageName{english}{Read other documents to see how we use solutions}{Consultez d'autres documents pour voir comment on utilise les solutions}}
 \newcommand{\@checksol@errmsg}{\IfLanguageName{english}{%
-		Unexpected (no)solution here; possible explanation: double solution, or missing \section to define statement
+		Unexpected (no)solution here; possible explanation: double solution, or missing \protect\section\space to define statement
 	}{%
-		Utilisation de (no)solution au mauvais endroit; possible cause: double solution ou \section manquante pour definir l'enonce
+		Utilisation de (no)solution au mauvais endroit; possible cause: double solution ou \protect\section\space manquante pour definir l'enonce
 }}
 \newcommand{\@checkstatmt@errmsg}[2]{\IfLanguageName{english}{%
-		Unexpected #1 here; did you miss a \begin{solution} ... \end{solution} or a \nosolution at the previous question?
+		Unexpected #1 here; did you miss a \protect\begin{solution}\space ... \protect\end{solution}\space or a \protect\nosolution\space at the previous question?
 	}{%
-		#2 inattendu ici; n'avez-vous pas oublie un \begin{solution} ... \end{solution} ou un \nosolution a la question precedente?
+		#2 inattendu ici; n'avez-vous pas oublie un \protect\begin{solution}\space ... \protect\end{solution}\space ou un \protect\nosolution\space a la question precedente ?
 }}
 \newcommand{\@checksolution}{%
 	\iftoggle{eplqa@waitingforsolution}{% OK: it defined and set to true
@@ -65,7 +65,6 @@
 {
 	\newmdenv[style=mysquare]{solution}
 }
-\AtBeginEnvironment{solution}{\@checksolution}
 
 \NewDocumentEnvironment{solfig}{mm}
 {\begin{center}\begin{minipage}{\textwidth}\centering\hspace{1em}}
@@ -73,7 +72,7 @@
 
 % \comment and \endcomment of the environment solution
 % does not work with newcomment
-\newcommand{\missingsolutiontext}[1]{
+\newcommand{\missingsolutiontext}[1]{%
 \IfLanguageName{english}{Sadly}{Malheureusement},
 #1
 \IfLanguageName{english}
@@ -96,15 +95,12 @@ Vous êtes encouragés à en soumettre une à l'adresse suivante}
 \ifthenelse{\equal{\Sol}{false}}
 {\newcommand{\nosolution}{}}
 {
-\newcommand{\nosolution}{
+\newcommand{\nosolution}{%
 \begin{solution}
 \missingsolutiontext{\QAlabel~\theQA}
 \end{solution}
 }
 }
-
-% May break at some point, as in theory \section is not a simple command. But surprisingly, it works for now.
-\apptocmd{\section}{\@checkstatement}{}{}
 
 % \nostatement: used to mark that a question doesn't have a statement yet.
 % We may have a solution nonetheless, so we must enforce the use of solution/nosolution
@@ -158,10 +154,5 @@ Vous êtes encouragés à en soumettre un à l'adresse suivante}
 \toggletrue{eplqa@waitingforstatement}
 \togglefalse{eplqa@waitingforsolution}
 %}
-\AtEndDocument{%
-\ifboolexpr{togl {eplqa@waitingforsolution} or not togl {eplqa@waitingforstatement}}{%
-	\PackageError{eplqa}{\@checkstatmt@errmsg{end of document}{Fin de document}}{\@help@rtfm}
-}{}
-}
 
 \endinput

--- a/src/eplqa.sty
+++ b/src/eplqa.sty
@@ -11,6 +11,39 @@
 
 \newcommand{\SolutionLabel}{Solution \IfLanguageName{english}{to}{à} \QAlabel~\theQA}
 
+\RequirePackage{etoolbox}
+
+\newtoggle{eplqa@waitingforsolution}
+\newtoggle{eplqa@waitingforstatement}
+
+\newcommand{\@help@rtfm}{\IfLanguageName{english}{Read other documents to see how we use solutions}{Consultez d'autres documents pour voir comment on utilise les solutions}}
+\newcommand{\@checksol@errmsg}{\IfLanguageName{english}{%
+		Unexpected (no)solution here; possible explanation: double solution, or missing \\section to define statement
+	}{%
+		Utilisation de (no)solution au mauvais endroit; possible cause: double solution ou \\section manquante pour définir l'énoncé
+}}
+\newcommand{\@checkstatmt@errmsg}[2]{\IfLanguageName{english}{%
+		Unexpected #1 here; did you miss a \\begin{solution} ... \\end{solution} or a \\nosolution at the previous question?
+	}{%
+		#2 inattendu ici; n'avez-vous pas oublie un \\begin{solution} ... \\end{solution} ou un \\nosolution à la question précédente?
+}}
+\newcommand{\@checksolution}{%
+	\iftoggle{eplqa@waitingforsolution}{% OK: it defined and set to true
+		\global\togglefalse{eplqa@waitingforsolution}
+		\global\toggletrue{eplqa@waitingforstatement}
+	}{% KO: undefined, or more probably not set to true
+		\PackageError{eplqa}{\@checksol@errmsg}{\@help@rtfm}
+	}
+}
+\newcommand{\@checkstatement}{%
+	\iftoggle{eplqa@waitingforstatement}{%
+		\global\togglefalse{eplqa@waitingforstatement}
+		\global\toggletrue{eplqa@waitingforsolution}
+	}{%
+		\PackageError{eplqa}{\@checkstatmt@errmsg{statement}{Enonce}}{\@help@rtfm}
+	}
+}
+
 \usepackage[framemethod=tikz]{mdframed}
 % greyarrow has much better handling of page breaks, see the link on stackoverflow for more info
 \def\SolStyle{greyarrow}
@@ -27,10 +60,11 @@
 \ifthenelse{\isundefined{\Sol}}{\def\Sol{true}}{}
 \ifthenelse{\equal{\Sol}{false}}
 {
-  \newenvironment{solution}{\expandafter\comment}{\expandafter\endcomment}
+	\newenvironment{solution}{\expandafter\comment}{\expandafter\endcomment}
 }
 {
-  \newmdenv[style=mysquare]{solution}
+	\newmdenv[style=mysquare]{solution}
+	\AtBeginEnvironment{solution}{\@checksolution}
 }
 
 \NewDocumentEnvironment{solfig}{mm}
@@ -52,9 +86,13 @@ Vous êtes encouragés à en soumettre une à l'adresse suivante}
 \end{center}
 \IfLanguageName{english}{or by mail}{ou par mail}.
 }
+% \nosubsolution: used in itemize/enumerate
+% TODO check if correctly used inside an itemize/enumerate + the question is also an itemize/enumerate and has the same number of items
 \newcommand{\nosubsolution}{
 \missingsolutiontext{\IfLanguageName{english}{this sub-question}{cette sous-question}}
 }
+
+% \nosolution: used to mark that a statement doesn't have a solution for now.
 \ifthenelse{\equal{\Sol}{false}}
 {\newcommand{\nosolution}{}}
 {
@@ -65,6 +103,16 @@ Vous êtes encouragés à en soumettre une à l'adresse suivante}
 }
 }
 
+% May break at some point, as in theory \section is not a simple command. But surprisingly, it works for now.
+\apptocmd{\section}{\@checkstatement}{}{}
+
+% \nostatement: used to mark that a question doesn't have a statement yet.
+% We may have a solution nonetheless, so we must enforce the use of solution/nosolution
+% FIXME: if this semantic is not correct, it is possible to use the two toggles to implement more complex conditions.
+% Ex: nostatement would deactivate waitingforsolution,
+% then solution would only check that we are not waiting for a statement already,
+% and would deactivate waitingforsolution nonetheless, and set waitingforstatement,
+% and as the statements check that we have waitingforsolution disabled, and waitingforstatement enabled, then it's OK
 \newcommand{\nostatement}{
 \IfLanguageName{english}{Sadly}{Malheureusement},
 \QAlabel~\theQA{}
@@ -79,6 +127,7 @@ Vous êtes encouragés à en soumettre un à l'adresse suivante}
 \IfLanguageName{english}{or by mail}{ou par mail}.
 }
 
+% MCQ support -- maybe should be split in another package?
 \RequirePackage{longtable} % so that table can be over several pages
 \renewcommand{\arraystretch}{1.5} % to bring space to the table
 
@@ -103,6 +152,16 @@ Vous êtes encouragés à en soumettre un à l'adresse suivante}
   \multicolumn{2}{|p{\textwidth}|}{\emph{Justification:}
     \ifthenelse{\equal{#3}{}}{TODO}{#3}
   }}\\
+}
+
+%\AtBeginDocument{%
+\toggletrue{eplqa@waitingforstatement}
+\togglefalse{eplqa@waitingforsolution}
+%}
+\AtEndDocument{%
+\ifboolexpr{togl {eplqa@waitingforsolution} or not togl {eplqa@waitingforstatement}}{%
+	\PackageError{eplqa}{\@checkstatmt@errmsg{end of document}{Fin de document}}{\@help@rtfm}
+}{}
 }
 
 \endinput

--- a/src/eplqa.sty
+++ b/src/eplqa.sty
@@ -18,14 +18,14 @@
 
 \newcommand{\@help@rtfm}{\IfLanguageName{english}{Read other documents to see how we use solutions}{Consultez d'autres documents pour voir comment on utilise les solutions}}
 \newcommand{\@checksol@errmsg}{\IfLanguageName{english}{%
-		Unexpected (no)solution here; possible explanation: double solution, or missing \\section to define statement
+		Unexpected (no)solution here; possible explanation: double solution, or missing \section to define statement
 	}{%
-		Utilisation de (no)solution au mauvais endroit; possible cause: double solution ou \\section manquante pour définir l'énoncé
+		Utilisation de (no)solution au mauvais endroit; possible cause: double solution ou \section manquante pour definir l'enonce
 }}
 \newcommand{\@checkstatmt@errmsg}[2]{\IfLanguageName{english}{%
-		Unexpected #1 here; did you miss a \\begin{solution} ... \\end{solution} or a \\nosolution at the previous question?
+		Unexpected #1 here; did you miss a \begin{solution} ... \end{solution} or a \nosolution at the previous question?
 	}{%
-		#2 inattendu ici; n'avez-vous pas oublie un \\begin{solution} ... \\end{solution} ou un \\nosolution à la question précédente?
+		#2 inattendu ici; n'avez-vous pas oublie un \begin{solution} ... \end{solution} ou un \nosolution a la question precedente?
 }}
 \newcommand{\@checksolution}{%
 	\iftoggle{eplqa@waitingforsolution}{% OK: it defined and set to true
@@ -64,8 +64,8 @@
 }
 {
 	\newmdenv[style=mysquare]{solution}
-	\AtBeginEnvironment{solution}{\@checksolution}
 }
+\AtBeginEnvironment{solution}{\@checksolution}
 
 \NewDocumentEnvironment{solfig}{mm}
 {\begin{center}\begin{minipage}{\textwidth}\centering\hspace{1em}}

--- a/src/q1/info-FSAB1401/exercises/info-FSAB1401-exercises.tex
+++ b/src/q1/info-FSAB1401/exercises/info-FSAB1401-exercises.tex
@@ -1,4 +1,4 @@
-\documentclass[fr]{../../../eplsummary}
+\documentclass[fr]{../../../eplexercises}
 \usepackage{../../../eplcode}
 
 \hypertitle[']{Informatique}{1}{FSAB}{1401}

--- a/src/q1/info-FSAB1401/summary/info-FSAB1401-summary.tex
+++ b/src/q1/info-FSAB1401/summary/info-FSAB1401-summary.tex
@@ -1,7 +1,7 @@
 \documentclass[fr]{../../../eplsummary}
 
 \usepackage{../../../eplcode}
-\usepackage[SIunits]{../../../eplunits}
+\usepackage{numprint}
 
 \hypertitle[']{Informatique}{1}{FSAB}{1401}
 {Beno\^it Legat\and Antoine Paris}

--- a/src/q2/chimie-EPL1301/summary/chimie-EPL1301-summary.tex
+++ b/src/q2/chimie-EPL1301/summary/chimie-EPL1301-summary.tex
@@ -347,7 +347,7 @@ $\Delta H = E(\ce{X^-})-E(\ce{X})=-E_A$
 \section{Liaisons intramoléculaires}
 \paragraph{Remarque} Représentation de Lewis: notation des atomes avec leurs $e^-$ de valence.
 
-\subparagraph{Exemple} L'azote:\hspace{0.7cm} \lewis{0.2.46.,N}
+\subparagraph{Exemple} L'azote:\hspace{0.7cm} \charge{0=\.,90=\.,180=\|,270=\.}{N}
 
 \subsection{Liaisons métalliques}
 Pour les métaux,
@@ -448,7 +448,7 @@ Doublet électronique apporté par un partenaire.
 \paragraph{Exemple:}
 \ce{BF3 + NH3}
 \begin{center}
-  \chemfig{B(-[4]F)(-[2]F)(-[6]F)}\hspace{0.3cm} + \hspace{0.3cm}\chemfig{\lewis{4,N}(-H)(-[2]H)(-[6]H)}$\longrightarrow$ \chemfig{B^{-}(-[4]F)(-[2]F)(-[6]F)}$\leftarrow$\chemfig{N^{+}(-[0]H)(-[2]H)(-[6]H)}
+  \chemfig{B(-[4]F)(-[2]F)(-[6]F)}\hspace{0.3cm} + \hspace{0.3cm}\chemfig{\charge{180=\|}{N}(-H)(-[2]H)(-[6]H)}$\longrightarrow$ \chemfig{B^{-}(-[4]F)(-[2]F)(-[6]F)}$\leftarrow$\chemfig{N^{+}(-[0]H)(-[2]H)(-[6]H)}
 \end{center}
 \subsubsection{Liaisons covalentes polarisées}
 La liaison peut être de deux types

--- a/src/q3/chimie-EPL1302/exam/2020/Janvier/All/chimie-EPL1302-exam-2020-Janvier-All.tex
+++ b/src/q3/chimie-EPL1302/exam/2020/Janvier/All/chimie-EPL1302-exam-2020-Janvier-All.tex
@@ -1,4 +1,7 @@
 \documentclass[fr]{../../../../../../eplexam}
+\usepackage{mhchem}
+\usepackage{enumitem}
+\usepackage[alsoload=synchem, binary-units=true]{siunitx}
 
 \hypertitle{Chimie}{3}{EPL}{1302}{2020}{Janvier}{All}
 {Baptiste Laterre}
@@ -6,35 +9,40 @@
 
 \section{Question 1 : RedOx}
 
-La pile à combustible est un procédé faisant intervenir 2 réactions en milieu alcalin : l’oxydation de $H_{2(g)}$ et la réduction de l’$O_{2(g)}$ de l’air ambiant. Voici une représentation de la situation étudiée :
+La pile à combustible est un procédé faisant intervenir 2 réactions en milieu alcalin : l’oxydation de \ce{H2_{(g)}} et la réduction de l’\ce{O2_{(g)}} de l’air ambiant. Voici une représentation de la situation étudiée :
 \begin{figure}[h]
-   \centering
+    \centering
     \includegraphics[scale=0.25]{pile_combustible.png}
+    \caption{Q1}
     \label{fig:my_label}
 \end{figure}
 
 \begin{enumerate}
     \item Ecrivez les 2 demi-réactions ainsi que la réaction globale.
     \item Sur le schéma, indiquez l’emplacement de la cathode, de l’anode, le sens des ions hydroxyde et le sens des électrons.
-    \item Trouvez le potentiel d’équilibre de chaque demi-réaction. \hspace{1em}
+    \item Trouvez le potentiel d’équilibre de chaque demi-réaction.
     \begin{tabular}{|c|c|c|}
     \hline
-     & $H_2O$ &$OH^-$\\
-     \hline
-     ${\Delta}_fG^o$ ($kJ/mol$) & -273.18 & -157.28\\
-     \hline
-\end{tabular}
+    & \ce{H2O} & \ce{OH-} \\
+    \hline
+    ${\Delta}_fG^o$ (\si{kJ/mol}) & -273.18 & -157.28\\
+    \hline
+    \end{tabular}
     \item Trouvez la force électromotrice standard. Le pH influence-t-il la force électromotrice ?
 \end{enumerate}
 
 \nosolution
 
 \section{Question 2 : cinétique}
-Voir Question 1 Septembre 2016
+
+Voir Question 1 Septembre 2016.
+
 \begin{solution}
 Voir Solution Question 1 Septembre 2016
 \end{solution}
+
 \section{Question 3 : cycle}
+
 Ci-après se trouvent les 5 étapes d’un cycle en système fermé.
 \begin{itemize}
     \item 1-2 : compression suivant la relation $pV^k$ = cste
@@ -43,37 +51,39 @@ Ci-après se trouvent les 5 étapes d’un cycle en système fermé.
     \item 4-5 : détente adiabatique
     \item 5-1 : refroidissement isochore
 \end{itemize}
-Pour ce cycle, le rapport de compression de $V_{max}/V_{min}$=12 ;
-la température max est de 1600°C;
-la pression max est de 160 bars;
-le gaz est comparable à de l’air pour lequel $\lambda$  = 1.3;
-l’apport de chaleur en 2-3 vaut 1000 $kJ/kg$;
-l’apport de chaleur en 3-4 vaut 500 $kJ/kg$;
-le refroidissement en 5-1 fait perdre 600 $kJ/kg$.
-À partir de ces données, trouvez les éléments suivants, en indiquant l’ordre dans lequel vous les avez trouvé : \newline
+Pour ce cycle, le rapport de compression de $V_\text{max}/V_\text{min}=12$;
+la température max est de \SI{1600}{\celsius};
+la pression max est de \SI{160}{\bar};
+le gaz est comparable à de l’air pour lequel $\lambda = 1.3$;
+l’apport de chaleur en 2-3 vaut \SI{1000}{kJ/kg};
+l’apport de chaleur en 3-4 vaut \SI{500}{kJ/kg};
+le refroidissement en 5-1 fait perdre \SI{600}{kJ/kg}.
+À partir de ces données, trouvez les éléments suivants, en indiquant l’ordre dans lequel vous les avez trouvé :
+
 \begin{center}
-
-
 \begin{tabular}{|m{1cm}|m{9cm}|m{2cm}|}
 \hline
-    &Valeur de k (transformation 1-2) & \\
+    & Valeur de $k$ (transformation 1-2) & \\
     \hline
-    &Pression à l’état 2 ($bar$) & \\
+    & Pression à l’état 2 (\si{bar}) & \\
     \hline
-    &Pression à l’état 5 ($bar$) & \\
+    & Pression à l’état 5 (\si{bar}) & \\
     \hline
-    &Variation d’énergie interne entre 1 et 2 ($J$)& \\
+    & Variation d’énergie interne entre 1 et 2 (\si{J}) & \\
     \hline
-    & Sachant que le travail total du cycle est de -1000$J$,
-    trouvez la masse de gaz dans le système ($kg$)& \\
+    & Sachant que le travail total du cycle est de \SI{-1000}{J},
+    trouvez la masse de gaz dans le système (\si{kg}) & \\
     \hline
-    &La température à l’état 3 ($K$) & \\
+    & La température à l’état 3 (\si{K}) & \\
     \hline
 \end{tabular}
 \end{center}
 Tracez également les diagrammes p/V et S/T pour ce cycle.
+
 \nosolution
+
 \section{Question 4 : théorie}
+
 Dans le cadre du premier principe, nous avons défini $\pi_T$ et $ \mu_{J-T}$.
 \begin{enumerate}
     \item Donnez une définition mathématique de $\pi_T$.
@@ -87,37 +97,61 @@ Dans le cadre du premier principe, nous avons défini $\pi_T$ et $ \mu_{J-T}$.
     %\end{figure}
     \item En se référant à l’expérience précédente, l’entropie du gaz change-t-elle au cours de la réaction ?
 \end{enumerate}
+
 \nosolution
+
 \section{Question 5 : QCM}
-\begin{enumerate}
-    \item Le $CO_2$ a son point triple à T = 59°C et en p = 5 atm. Quelle transformation se passe lors du passage de T = 0°C à 60°C, à une pression de 20 atm ? \newline
-    $\square$ Le $CO_2$ reste solide; $\square$ Le $CO_2$ passe de l'état solide à l'état liquide; $\square$ Le $CO_2$ passe de l'état solide à l'état de vapeur ; $\square$ Le $CO_2$ reste liquide; $\square$ Le $CO_2$ passe de l'état liquide à l'état solide \newline
-    \item Une pompe à chaleur travaille selon un cycle de Carnot inversé entre une température extérieure proche de 0°C et une température intérieure de 20°C. Quel est le coefficient de performance de cette machine ? \newline
-    $\square$ 15.7; $\square$ 12.7; $\square$ 14.7; $\square$ 13.7; $\square$ 16.7 \newline
-    \item Quelle est la définition générale de l'activité d'un composant gazeux ? \newline
-    $\square$ $p_i/p_i^0$; $\square$ $p_i^0/1$; $\square$ $p_i/1$; $\square$ $p_i/p^0$; $\square$ $p/p_i^0$ \newline
-    \item La tension de vapeur à 100°C d'une solution aqueuse de 0.4M en $KNO_3$ est de 605.52 Torr (1 atm = 760 Torr). Quelle est l'activité de l'eau dans cette solution ? \newline
-    $\square$ 0.4; $\square$ 0.797; $\square$ Impossible de calculer l'activité sur base des données fournies; $\square$ 242.21; $\square$ 0.319 \newline
-    \item La tension de vapeur de l'eau à 25°C est de 23.76 Torr et son enthalpie standard de vaporisation est de 44 $kJ/mol$. Estimez la tension de vapeur de l'eau à 40°C, en Torr. \newline
-    $\square$ 55.65; $\square$ 23.78; $\square$ 38.02; $\square$ 24.96; $\square$ 10.14 \newline
-    \item Après avoir raccordé votre maison au réseau d'eau, vous constatez que lorsqu'un robinet de 5 $mm$ de diamètre est totalement ouvert, le débit est de 10 $L/min$. Sachant que le niveau d'eau du château d'eau se situe 60 $m$ plus haut que votre robinet, estimez $w_f$, les pertes dans l'ensemble des tuyauteries liant votre maison au château d'eau, en $J/kg$.\newline
-    $\square$ 527; $\square$ 553; $\square$ 589; $\square$ 490; $\square$ 623; $\square$ 467 \newline
-    \item Quelle expression, parmi celles-ci, est eronnée ? \newline
+
+\begin{enumerate}[itemsep=1em]
+    \item Le \ce{CO2} a son point triple à $T=\SI{59}{\celsius}$ et en $p = \SI{5}{atm}$. Quelle transformation se passe lors du passage de T = 0°C à 60°C, à une pression de 20 atm ?
+
+    $\square$ Le \ce{CO2} reste solide; $\square$ Le \ce{CO2} passe de l'état solide à l'état liquide; $\square$ Le \ce{CO2} passe de l'état solide à l'état de vapeur ; $\square$ Le \ce{CO2} reste liquide; $\square$ Le \ce{CO2} passe de l'état liquide à l'état solide
+
+    \item Une pompe à chaleur travaille selon un cycle de Carnot inversé entre une température extérieure proche de \SI{0}{\celsius} et une température intérieure de \SI{20}{\celsius}. Quel est le coefficient de performance de cette machine ?
+
+    $\square$ 15.7; $\square$ 12.7; $\square$ 14.7; $\square$ 13.7; $\square$ 16.7
+
+    \item Quelle est la définition générale de l'activité d'un composant gazeux ?
+
+    $\square$ $p_i/p_i^0$; $\square$ $p_i^0/1$; $\square$ $p_i/1$; $\square$ $p_i/p^0$; $\square$ $p/p_i^0$
+
+    \item La tension de vapeur à \SI{100}{\celsius} d'une solution aqueuse de \SI{0.4}{\Molar} en \ce{KNO3} est de \SI{605.52}{\torr} (\SI{1}{atm} = \SI{760}{\torr}). Quelle est l'activité de l'eau dans cette solution ?
+
+    $\square$ 0.4; $\square$ 0.797; $\square$ Impossible de calculer l'activité sur base des données fournies; $\square$ 242.21; $\square$ 0.319
+
+    \item La tension de vapeur de l'eau à \SI{25}{\celsius} est de \SI{23.76}{\torr} et son enthalpie standard de vaporisation est de \SI{44}{kJ/mol}. Estimez la tension de vapeur de l'eau à \SI{40}{\celsius}, en \si{\torr}.
+
+    $\square$ 55.65; $\square$ 23.78; $\square$ 38.02; $\square$ 24.96; $\square$ 10.14
+
+    \item Après avoir raccordé votre maison au réseau d'eau, vous constatez que lorsqu'un robinet de \SI{5}{mm} de diamètre est totalement ouvert, le débit est de \SI{10}{L/min}. Sachant que le niveau d'eau du château d'eau se situe \SI{60}{m} plus haut que votre robinet, estimez $w_f$, les pertes dans l'ensemble des tuyauteries liant votre maison au château d'eau, en \si{J/kg}.
+
+    $\square$ 527; $\square$ 553; $\square$ 589; $\square$ 490; $\square$ 623; $\square$ 467
+
+    \item Quelle expression, parmi celles-ci, est erronée ?
+
     $\square$ ${\Big(\frac{\partial H}{\partial p}\Big)}_S$ = $V$;
     $\square$ ${\Big(\frac{\partial U}{\partial S}\Big)}_V$ = $T$;
     $\square$ ${\Big( \frac{\partial T}{\partial V} \Big)}_S$ = - ${\Big( \frac{\partial p}{\partial S}\Big)}_V$;
-    $\square$ ${\Big( \frac{\partial T}{\partial p}\Big)}_S$ = ${\Big(\frac{\partial V}{\partial S}\Big)}_H$ \newline
-    \item Sur base du diagramme représentant la variation d'énergie libre molaire avec la concentration d'une solution binaire A-B régulière, répondez à la question suivante : laquelle de ces expression n'est pas valable à la concentration $x_B$? (\textbf{FIGURE TYPE MAIS PAS EXACTE})\newline
+    $\square$ ${\Big( \frac{\partial T}{\partial p}\Big)}_S$ = ${\Big(\frac{\partial V}{\partial S}\Big)}_H$
+
+    \item Sur base du diagramme représentant la variation d'énergie libre molaire avec la concentration d'une solution binaire A-B régulière, répondez à la question suivante : laquelle de ces expression n'est pas valable à la concentration $x_B$? (\textbf{FIGURE TYPE MAIS PAS EXACTE})
+
     \begin{figure}[h]
         \centering
         \includegraphics[scale=0.5]{melange.png}
     \end{figure}
     $\square$ $\mu_B<\mu^B$; $\square$ $\mu^A < \mu^B$; $\square$ $\mu_A < \mu_B$;
-    $\square$ $\mu_A > \mu^A $; $\square$ $\omega >0$ \newline
-    \item Quel est le lien entre la vitesse la plus probable $c_p$ et la vitesse quadratique moyenne $\sqrt{\bar{c^2}}$ d'une distribution de vitesse de Maxwell - Boltzmann? $c_p$ = ... \newline
-    $\square$ $\sqrt{\frac{2}{3}\bar{c^2}}$; $\square$ $\sqrt{\bar{c^2}}$; $\square$ $\sqrt{\frac{3}{2}\bar{c^2}}$; $\square$ $\frac{3}{2} \sqrt{\bar{c^2}}$; $\square$ $\frac{2}{3}\sqrt{\bar{c^2}}$ \newline
-    \item Pour caractériser le compresseur d'un turbo, vous diposez des données suivantes : puissance de 5$kW$ et débit d'air de 80$g/s$. Quelle est la pression abolue à l'admission du moteur, c'est-à-dire après la compression, si la temparature ambiante est de 25°C et la pression ambiante de 1 $bar$ ? (hypothèse: transformation réversible) \newline
+    $\square$ $\mu_A > \mu^A $; $\square$ $\omega >0$
+
+    \item Quel est le lien entre la vitesse la plus probable $c_p$ et la vitesse quadratique moyenne $\sqrt{\bar{c^2}}$ d'une distribution de vitesse de Maxwell - Boltzmann? $c_p$ = ...
+
+    $\square$ $\sqrt{\frac{2}{3}\bar{c^2}}$; $\square$ $\sqrt{\bar{c^2}}$; $\square$ $\sqrt{\frac{3}{2}\bar{c^2}}$; $\square$ $\frac{3}{2} \sqrt{\bar{c^2}}$; $\square$ $\frac{2}{3}\sqrt{\bar{c^2}}$
+
+    \item Pour caractériser le compresseur d'un turbo, vous disposez des données suivantes : puissance de \SI{5}{kW} et débit d'air de \SI{80}{g/s}. Quelle est la pression absolue à l'admission du moteur, c'est-à-dire après la compression, si la température ambiante est de 25°C et la pression ambiante de 1 $bar$ ? (hypothèse: transformation réversible)
+
     $\square$ 2.18; $\square$ 1.52; $\square$ 1.96; $\square$ 2.86; $\square$ 1.37
 \end{enumerate}
+
 \nosolution
+
 \end{document}

--- a/src/q3/edp-EPL1103/exam/2013/Juin/All/edp-EPL1103-exam-2013-Juin-All.tex
+++ b/src/q3/edp-EPL1103/exam/2013/Juin/All/edp-EPL1103-exam-2013-Juin-All.tex
@@ -125,6 +125,8 @@ $\fpart{u}{\theta}(r, 2\pi) = \frac{U_0}{2\pi}$ de l'autre.
 \section{}
 Idem que la question 3 de Janvier 2012.
 
+\nosolution
+
 \section{}
 Calculez l'intégrale suivante
 $$\int_0^\infty\frac{\cos(x)}{x^2+a^2}\dif x$$

--- a/src/q3/info-FSAB1402/exam/2006/Janvier/All/info-FSAB1402-exam-2006-Janvier-All.tex
+++ b/src/q3/info-FSAB1402/exam/2006/Janvier/All/info-FSAB1402-exam-2006-Janvier-All.tex
@@ -106,4 +106,6 @@ un fragment de code pour illustrer le concept.
 \item Agent
 \end{itemize}
 
+\nosolution
+
 \end{document}

--- a/src/q3/maths-discretes-EPL1108/exam/2020/Janvier/All/maths-discretes-EPL1108-exam-2020-Janvier-All.tex
+++ b/src/q3/maths-discretes-EPL1108/exam/2020/Janvier/All/maths-discretes-EPL1108-exam-2020-Janvier-All.tex
@@ -29,8 +29,10 @@ Vous réalisez l'expérience du dé (non-truqué : la probabilité d'obtenir une
     \item $\lim_{N \to \infty} P(0.1 \leq K/N \leq 0.2$ = 
     \item $\lim_{N \to \infty} P(K \leq N/6 + \sqrt{5N}/3$ =
 \end{itemize}
+\nosolution
 \section{Question 8}
 Concernait l'ordre du groupe quotient G/H, en devant trouver |H| connaissant G.
+\nosolution
 \section{Question 9}
 Alice et Bob se rendent à la poste, entre 15 et 16h. Leur arrivée est indépendante et équiprobable. Pour simplifier le calcul, on considérera des temps entre 0 et 1 : 0 = 15h, 1 = 16h, ¼ = 15h15, ½ = 15h30, … Soit $T_A$ et $T_B$ les variables aléatoires des heures d’arrivées de Alice et Bob à la poste. Nous définirons $T_{min}$ = $min (T_A,T_B)$ et $T_{max}$ = $max (T_A,T_B)$. 
 \begin{enumerate}

--- a/src/q4/mmc-MECA1901/exam/2013/Janvier/Majeure/mmc-MECA1901-exam-2013-Janvier-Majeure.tex
+++ b/src/q4/mmc-MECA1901/exam/2013/Janvier/Majeure/mmc-MECA1901-exam-2013-Janvier-Majeure.tex
@@ -9,14 +9,24 @@
 \section{Théorie}
 \begin{enumerate}
 \item Enoncer et démontrer le théorème du transport de Reynolds(variante de base). Montrer ensuite comment le principe de conservation de la masse permet d'établir une variante simplifiée de ce théorème.
+\item Enoncer et démontrer l'interprétation géométrique de $D_{33}$ et $D_{21}$ en précisant leur dimension physique et leur unité
+\item Définir le concept de ligne d'émission et établir les formules qui permettent d'en faire le calcul en partant d'une représentation lagrangienne du mouvement
+\item Enoncer le principe de conservation du moment de quantité de mouvement et établir sa forme locale. Expliquer quelles en sont les conséquences en termes de contraintes et de directions principales.
+\item Enoncer, démontrer et interpréter le théorème de l'énergie cinétique.
+\end{enumerate}
 
 \begin{solution}
+\begin{enumerate}
+
+\item \textbf{Enoncer et démontrer le théorème du transport de Reynolds(variante de base). Montrer ensuite comment le principe de conservation de la masse permet d'établir une variante simplifiée de ce théorème.}
+
+
 Théorème du transport de Reynolds: \textit{ Soit $\Omega(t)$ une portion quelconque se déformant au cours du temps. On suppose que sa frontière $\partial \Omega (t)$ a pour normale unitaire sortante $n(t)$. Pour une quantité physique arbitraire $\phi(t)$ associée à un point matériel appartenant au volume matériel ou à la frontière on a:}
 \begin{equation}
 \frac{D}{Dt}I(t)=\int_{\Omega_{0}}\left(\frac{\partial\phi(X,t)}{\partial t}J+\phi(X,t)\frac{\partial J}{\partial t}\right)dV
 \end{equation}
 Avec $J=\frac{\partial x}{\partial X} \rightarrow \frac{\partial J}{\partial t} = J\nabla.v$
-En remplacant dans l'équation précédente on obtient:
+En remplaçant dans l'équation précédente on obtient:
 \begin{equation}
 \frac{D}{Dt}I(t)=\int_{\Omega_{0}}J\left(\frac{\partial\phi(X,t)}{\partial t}+\phi(X,t)\nabla.v\right)dV
 \end{equation}
@@ -28,44 +38,42 @@ En appliquant la dérivée matérielle:
 \begin{equation}
 \frac{D}{Dt}I(t)=\int_{\Omega(t)}\left(\frac{\partial\phi}{\partial t}+v.\nabla\phi+\phi\nabla.v\right)dv=\int_{\Omega(t)}\left(\frac{\partial\phi}{\partial t}+\nabla.(\phi v)\right)dv
 \end{equation}
-Par le théoreme de la divergence on obtient enfin :
+Par le théorème de la divergence on obtient enfin :
 \begin{equation}
 \frac{D}{Dt}I(t)=\int_{\Omega(t)}\frac{\partial\phi}{\partial t}dv + \oint_{\partial\Omega(t)}\phi v.\hat{n}ds
 \end{equation}
-En utilisant le théorême de la conservation de la masse et le TTR (avec $\phi = \rho$):
+En utilisant le théorème de la conservation de la masse et le TTR (avec $\phi = \rho$):
 \begin{equation}
 \frac{D}{Dt}M(t)=\int_{\Omega(t)}\phi dv=0
 \end{equation}
 \begin{equation}
 \frac{D}{Dt}M(t)=\int_{\Omega(t)}\left(\frac{\partial\rho}{\partial t}+\nabla.(\rho v)\right)dv=0 \rightarrow \frac{\partial\rho}{\partial t}+\nabla.(\rho v)=0
 \end{equation}
-\end{solution}
 
-\item Enoncer et démontrer l'interprétation géométrique de $D_{33}$ et $D_{21}$ en précisant leur dimension physique et leur unité
 
-\begin{solution}
+\item \textbf{Enoncer et démontrer l'interprétation géométrique de $D_{33}$ et $D_{21}$ en précisant leur dimension physique et leur unité}
+
+
 Voir question précédentes pour interprétation physique.
 Unité:
 \begin{align*}
 \left[D\right]&=\frac{m}{ms}\\
 & = s^{-1}
 \end{align*}
-\end{solution}
 
-\item Définir le concept de ligne d'émission et établir les formules qui permettent d'en faire le calcul en partant d'une représentation lagrangienne du mouvement
+\item \textbf{Définir le concept de ligne d'émission et établir les formules qui permettent d'en faire le calcul en partant d'une représentation lagrangienne du mouvement}
 
-\begin{solution}
 Une ligne d'émission à travers un point $x^*$ à un instant $\tau$ donné est la courbe constituée de toutes les particules qui sont passées par le point $x^*$.
 On peut l'obtenir à partir de la définition lagrangienne en utilisant:
 \begin{equation}
 x=\chi(\chi^{-1}(x^*,t),\tau)
 \end{equation}
-\end{solution}
 
-\item Enoncer le principe de conservation du moment de quantité de mouvement et établir sa forme locale. Expliquer quelles en sont les conséquences en termes de contraintes et de directions principales.
 
-\begin{solution}
-Le moment de quatité de mouvement est défini comme étant :
+\item \textbf{Enoncer le principe de conservation du moment de quantité de mouvement et établir sa forme locale. Expliquer quelles en sont les conséquences en termes de contraintes et de directions principales.}
+
+
+Le moment de quantité de mouvement est défini comme étant :
 \begin{equation}
 \textbf{L} = \int_{\Omega}\rho \textbf{x} \wedge \textbf{v} \mathrm{d}V
 \end{equation}
@@ -86,7 +94,7 @@ Pour établir la forme locale, on applique le Théorème de Transport de Reynold
 \PTDeriv{ }{t} \Integr{\Omega}{}{\rho \textbf{x} \wedge \textbf{v}}{V} = \Integr{\Omega}{}{\rho \PTDeriv{ }{t}(\textbf{x} \wedge \textbf{v})}{V} = \Integr{\Omega}{}{\rho \textbf{x} \wedge \PTDeriv{\textbf{v}}{t}}{V}
 \end{equation}
 
-On peut aussi calculer le couple associé aux contraintes de contact, en utilisant successivment : l'expression de la force tangentielle en fonction du tenseur des contraintes, la notation indicielle pour le produit vectoriel, Green-Ostrogradski et pour finir la dérivée d'un produit :
+On peut aussi calculer le couple associé aux contraintes de contact, en utilisant successivement : l'expression de la force tangentielle en fonction du tenseur des contraintes, la notation indicielle pour le produit vectoriel, Green-Ostrogradski et pour finir la dérivée d'un produit :
 \begin{equation}
 \oint_{\partial \Omega} \textbf{x} \wedge \textbf{t} \mathrm{d}s = \oint_{\partial \Omega} \textbf{x} \wedge \hat{\textbf{n}} \cdot \uuline{\sigma} \mathrm{d}s = \oint_{\partial \Omega} e_{ijk} x_j n_l  \sigma_{lk} \mathrm{d}s = \Integr{\Omega}{}{\PDeriv{}{x_l} (e_{ijk} x_j \sigma_{lk})}{V}
 \end{equation}
@@ -106,13 +114,12 @@ e_{ijk}\sigma_{jk} = 0 \rightarrow \uuline{\sigma} = \uuline{\sigma}^T
 \end{equation}
 
 Le tenseur des contraintes est donc symétrique. Par conséquent, la contrainte dans la direction $\Base{1}$ d'une face de normale $\Base{2}$ est égale à la contrainte dans la direction $\Base{2}$ d'une face de normale $\Base{1}$. Ces contraintes sont nulles (si la direction 1 est différente de la 2) pour les directions principales.
-\end{solution}
 
 
 %Vicnent, 'jai fini je vais dodo k bonne nuit :) ya du paté plus haut je vais réparer
-\item Enoncer, démontrer et interpréter le théorème de l'énergie cinétique.
+\item \textbf{Enoncer, démontrer et interpréter le théorème de l'énergie cinétique.}
 
-\begin{solution}
+
 Nous cherchons à dériver l'expression du théorème de l'énergie cinétique, pour ce faire partons de l'expression de la conservation de la quantité de mouvement.
 \begin{equation*}
 \rho \PTDeriv{\bm{v}}{t}=\rho \bm{f}+\nabla \cdot \bm{\sigma}
@@ -152,8 +159,6 @@ Si on regarde ce qu'il advient du double produit contracté suite à cette déco
 \end{equation*}
 % J4ai pas fini canard il dit que ca bug ici mais je vois pas pq voila reparé
 
-
-
 Cependant on peut en plus laisser tomber le dernier terme car il fait intervenir des puissances qui ne sont non nulles que s'il n'y a pas de couple volumiques. Nous supposerons que nous avons affaire à ce cas-là. Réécrivons donc la formulation finale de la conservation de l'énergie cinétique (le TTR est utilisé ici parce qu'il est trop bonne!)
 \begin{equation*}
   \frac{D}{Dt}\int_{\text{$\Omega(t)$}}\rho \frac{\bm{v}\cdot \bm{v}}{2}dv=\int_{\Omega(t)}\rho\bm{f}\cdot \bm{v}dv+\oint_{\partial\Omega(t}\bm{t}\cdot\bm{v}ds-\int_{\Omega(t)}\bm{\sigma}:{\cal\bm{D}}dv
@@ -164,8 +169,9 @@ On peut interpréter la somme du membre de droite comme ceci
 \frac{D}{Dt}K=W^d+W^c-W^i
 \end{equation*}
 Ces termes représentent respectivement les puissances des forces volumiques, des forces de contact et des efforts internes.
-\end{solution}
+
 \end{enumerate}
+\end{solution}
 
 
 \end{document}

--- a/src/q4/mmc-MECA1901/exam/2014/Janvier/Majeure/mmc-MECA1901-exam-2014-Janvier-Majeure.tex
+++ b/src/q4/mmc-MECA1901/exam/2014/Janvier/Majeure/mmc-MECA1901-exam-2014-Janvier-Majeure.tex
@@ -8,11 +8,30 @@
 
 \section{Théorie}
 
-\begin{itemize}
-  \item Interpréter le terme $D_{23}$ du tenseur des taux de déformation. Utiliser un dessin pour
+\begin{enumerate}
+\item Interpréter le terme $D_{23}$ du tenseur des taux de déformation. Utiliser un dessin pour
 votre explication.
+\item \textbf{Etablir} l'expression du rotationnel d’un champ vectoriel $\mathbf{v}$ en coordonnées-composantes
+cylindriques.
+\item Interprétez les termes du théorème de Reynolds écrit pour un volume matériel $\Omega(t)$,
+dans ces deux expressions
+\begin{align}
+\frac{D}{D\text{t}}\mathcal{I}(t) & = \int_{\text{$\Omega$}(\text{t})}\left(\frac{D\phi}{D\text{t}}+\phi \nabla \cdot \mathbf{v} \right) \dif v\\
+& = \int_{\text{$\Omega$}(\text{t})}\frac{\partial \phi}{\partial \text{t}} \text{dv} +\oint_{\partial \text{$\Omega$}(\text{t})}\phi \mathbf{v} \cdot \hat{\mathbf{n}} \dif s.
+\end{align}
+Comment passe-t-on de l'une à l'autre?
+\item Quelle est la plus grande contrainte normale principale dans un tube mince soumis à
+une pression interne?
+\item Donner les 4 idées/hypothèses qui mènent à l’établissement du modèle de fluide visqueux
+newtonien. Faire le lien avec l’expression de la loi des contraintes de ce fluide.
+\end{enumerate}
+
 
 \begin{solution}
+\begin{enumerate}
+
+\item
+
 Rappelons d'abord la définition de $D_{23}$\footnote{$D_{23}$ et $D_{32}$ ont une valeur identique mais ne sont pas équivalents physiquement. En effet, le $1^{er}$ indice correspond à la direction de la normale sortante de la face d'application, tandis que le $2^{eme}$ correspond à la direction de la contrainte.} en coordonnées cartésiennes :
 
 \begin{equation}
@@ -22,7 +41,6 @@ D_{23} = D_{32} = \frac{1}{2}(\PDeriv{v_2}{x_3}+\PDeriv{v_3}{x_2})
 Il s'agit du \textit{taux de déformations de cisaillement} associé aux directions $e_2,e_3$ et comporte deux termes, mesurant la variation de la composante en $e_2$ de la vitesse selon $x_3$ et vice versa.
 
 Voir \figuref{def}.
-\end{solution}
 
 \begin{figure}[H]
 \centering
@@ -31,10 +49,8 @@ Voir \figuref{def}.
 \label{fig:def}
 \end{figure}
 
-\item \textbf{Etablir} l'expression du rotationnel d’un champ vectoriel $\mathbf{v}$ en coordonnées-composantes
-cylindriques.
+\item
 
-\begin{solution}
 L'astuce ici est de se rappeler que les vecteurs de base cylindriques varient dans l'espace. Par conséquent, quand on applique un opérateur différentiel spatial, des termes ``supplémentaires'' vont apparaitre. On prend l'expression de l'opérateur nabla en coordonnées cylindriques :
 
 \begin{equation}
@@ -64,17 +80,9 @@ On effectue maintentant le produit vectoriel :
 \end{align}
 
 En réarrangeant les termes, on retrouve bien l'expression du rotationnel en coordonnées cylindriques.
-\end{solution}
 
-\item Interprétez les termes du théorème de Reynolds écrit pour un volume matériel $\Omega(t)$,
-dans ces deux expressions
-\begin{align}
-  \frac{D}{D\text{t}}\mathcal{I}(t) & = \int_{\text{$\Omega$}(\text{t})}\left(\frac{D\phi}{D\text{t}}+\phi \nabla \cdot \mathbf{v} \right) \dif v\\
-                                    & = \int_{\text{$\Omega$}(\text{t})}\frac{\partial \phi}{\partial \text{t}} \text{dv} +\oint_{\partial \text{$\Omega$}(\text{t})}\phi \mathbf{v} \cdot \hat{\mathbf{n}} \dif s.
-\end{align}
-Comment passe-t-on de l'une à l'autre?
+\item
 
-\begin{solution}
 \begin{align*}
 \frac{D}{D\text{t}}\mathcal{I}=\int_{\text{$\Omega$}(\text{t})}\left(\frac{D\phi}{D\text{t}}+\phi \nabla \cdot \text{v} \right) \text{dv}\\
 \frac{D}{D\text{t}}\mathcal{I}=\int_{\text{$\Omega$}(\text{t})}\frac{\partial \phi}{\partial \text{t}} \text{dv} +\oint_{\partial \text{$\Omega$}(\text{t})}\phi \text{v} \cdot \hat{\text{n}}\text{ds}
@@ -93,22 +101,14 @@ Montrons maintenant comment passer de la première expression à la seconde:
 & = \int_{\text{$\Omega$}(\text{t})}\frac{\partial \phi}{\partial \text{t}}dv +\oint_{\partial \text{$\Omega$}(t)}\phi \bm{v}\cdot \hat{n}ds
 \end{align*}
 Pour passer de la première à la seconde ligne, il faut développer la dérivée particulaire. Pour passer de la seconde ligne à la troisième, il faut se souvenir de la définition de dérivée d'un produit et pour passer à la dernière (mais non la moindre\dots) ligne, il faut utiliser le théorème de Green-Ostrogradski.
-\end{solution}
-
 
 \item
-Quelle est la plus grande contrainte normale principale dans un tube mince soumis à
-une pression interne?
 
-\begin{solution}
 La plus grande contrainte est $\sigma_{\theta \theta}$, aussi appelé l'effort circonférentiel. (Voir exemple 4.2.4 du livre.)
 On a trois candidats : $\sigma_{rr}$, $\sigma_{\theta \theta}$ et $\sigma_{zz}$. La contrainte $\sigma_{rr}$ est imposée aux surfaces intérieures et extérieures du tube, et vaut $p_i$ à l'intérieur et $p_e$ à l'extérieur ($p_i > p_e$), on peut donc dire que $p_i$ est la valeur maximale de $\sigma_{rr}$. En suivant les calculs détaillés p114 du livre, on trouve qu'en outre $\sigma_{\theta \theta} = \frac{p_iD}{2h} \gg p_i$ et $\sigma_{zz} = \sigma_{\theta \theta}/2$
-\end{solution}
 
-\item Donner les 4 idées/hypothèses qui mènent à l’établissement du modèle de fluide visqueux
-newtonien. Faire le lien avec l’expression de la loi des contraintes de ce fluide.
+\item
 
-\begin{solution}
 \mypar{1) Au repos pas d'autres efforts internes que la pression: \\}
 On parle ici de la pression hydrostatique - qui correspond à la pression thermodynamique p - et non pas de la pression des examens :) :
 \begin{equation*}
@@ -158,8 +158,8 @@ On sait que $\bm{\sigma}=\bm{\tau}-p\cal{I}$, et que le taux de déformation peu
 \bm{\tau}=2\mu \left( \bm{D}-\frac{1}{3}(\trace\bm{D})\cal{I}\right)+\left(\frac{2}{3}\mu+\lambda\right)(\trace\bm{D})\cal{I}\\
 \bm{\sigma}=2\mu \left( \bm{D}-\frac{1}{3}(\trace\bm{D})\cal{I}\right)+\left(\frac{2}{3}\mu+\lambda\right)(\trace\bm{D})\cal{I}-\text{p} \cal{I}
 \end{align*}
+\end{enumerate}
 \end{solution}
-\end{itemize}
 
 \includepdf[pages={3}]{mmc-MECA1901-exam-2014-Janvier-Majeure-Official.pdf}
 \ifthenelse{\equal{\Sol}{false}}{}

--- a/src/q4/mmc-MECA1901/exam/2014/Janvier/Mineure/mmc-MECA1901-exam-2014-Janvier-Mineure.tex
+++ b/src/q4/mmc-MECA1901/exam/2014/Janvier/Mineure/mmc-MECA1901-exam-2014-Janvier-Mineure.tex
@@ -9,9 +9,18 @@
 \section{Théorie}
 
 \begin{enumerate}
-  \item
-Interpréter le terme $\varepsilon_{12}$ du tenseur des déformations. Utiliser un dessin pour votre
+  \item Interpréter le terme $\varepsilon_{12}$ du tenseur des déformations. Utiliser un dessin pour votre
 explication.
+  \item En traction simple de valeur $\sigma$, que vaut la contrainte tangentielle maximale? Pour
+  répondre à la question, construisez le cercle de Mohr. Indiquez également la facette
+  pour laquelle la contrainte tangentielle est maximale.
+  \item Expliquer la décomposition sphérique et déviatoire d’un tenseur. Illustrer son utilité.
+  \item Utiliser la loi de comportement d'un matériau hyper-élastique pour illustrer \textbf{deux}
+  principes d'établissement de lois de constitution.
+  \item Montrer que dans le cas d’un fluide visqueux newtonien incompressible et indatable,
+  une condition nécessaire sur l’écoulement est que son champ de vitesse soit à divergence
+  nulle? Pour ce cas, simplifier l’expression de la loi de constitution des contraintes.
+\end{enumerate}
 
 \begin{figure}[H]
 \centering
@@ -21,12 +30,13 @@ explication.
 \end{figure}
 
 \begin{solution}
+\begin{enumerate}
+\item
 \mypar{Complément de réponse:}
 
-On peut également interpréter géométriquement les termes non diagonaux du tenseur de déformation - $\varepsilon_{12}$ en l'occurence. Il s'agit de la demi variation d'angle qu'a subit un angle droit situé dans le volume initial (cfr figure \ref{yoloswagderoucarnage}).
+On peut également interpréter géométriquement les termes non diagonaux du tenseur de déformation - $\varepsilon_{12}$ en l'occurrence. Il s'agit de la demi variation d'angle qu'a subit un angle droit situé dans le volume initial (cfr figure~\ref{yoloswagderoucarnage}).
 
 Voir \figuref{e12}.
-\end{solution}
 
 \begin{figure}[H]
 \centering
@@ -36,10 +46,7 @@ Voir \figuref{e12}.
 \end{figure}
 
 
-  \item
-En traction simple de valeur $\sigma$, que vaut la contrainte tangentielle maximale? Pour
-répondre à la question, construisez le cercle de Mohr. Indiquez également la facette
-pour laquelle la contrainte tangentielle est maximale.
+\item
 
 \begin{figure}[H]
 \centering
@@ -47,10 +54,10 @@ pour laquelle la contrainte tangentielle est maximale.
 \caption{question sur mohr (pas sur)}
 \label{fig:mohr}
 \end{figure}
-\begin{solution}
+
 \mypar{Complément de réponse:}
 
-La contrainte tangeancielle est maximale dans le plan à 45 degrés. En effet, comme il n'y a qu'un cercle de Mohr cette dernière se trouve à mi-chemin entre les deux directions principales associées au cercle.\footnote{Si il y avait trois cercles la contraintes maximale serait à 45 degrés de la contrainte maximale et minimale. Rappel: Les valeurs de $\sigma$ doivent être dans l'orde croissant}. En fait, quand on suit le contour d'un cercle de Mohr associé à deux valeurs principales, on parcourt toutes les directions entre les deux directions principales associées à ces valeurs principales. A l'apogée du cerlce on est donc parfaitement à 45 degrés des deux directions principales associées aux valeurs principales du cerlce qu'on ``suit''. %Remarque: on peut aussi trouver se plan en calculant les vecteurs propres de la matrice $det(\sigma - \lambda*I)=0$
+La contrainte tangeancielle est maximale dans le plan à 45 degrés. En effet, comme il n'y a qu'un cercle de Mohr cette dernière se trouve à mi-chemin entre les deux directions principales associées au cercle.\footnote{Si il y avait trois cercles la contraintes maximale serait à 45 degrés de la contrainte maximale et minimale. Rappel: Les valeurs de $\sigma$ doivent être dans l'ordre croissant}. En fait, quand on suit le contour d'un cercle de Mohr associé à deux valeurs principales, on parcourt toutes les directions entre les deux directions principales associées à ces valeurs principales. A l'apogée du cercle on est donc parfaitement à 45 degrés des deux directions principales associées aux valeurs principales du cercle qu'on ``suit''. %Remarque: on peut aussi trouver se plan en calculant les vecteurs propres de la matrice $det(\sigma - \lambda*I)=0$
 
 \mypar{Autre manière de trouver la facette à force tangentielle maximale:}
 
@@ -78,11 +85,9 @@ En regardant le cercle de Mohr, on voit que $\tau = \tau_{max}$ quand $\sigma_n 
 Donc $n_1 = 1/\sqrt{2}$, et $n_2$ et $n_3$ quelquonques est la famille des normales des plans à force tangentielle maximale. On a donc bien que l'angle entre l'axe parallèle à la traction et la normale de la facette à force tangentielle vaut 45 degrés, car $\uline{\hat{n}} \cdot \Base{1} = \cos(\theta) = 1/\sqrt{2}$.
 
 Voir \figuref{mohr}.
-\end{solution}
 
-\item Expliquer la décomposition sphérique et déviatoire d’un tenseur. Illustrer son utilité.
+\item
 
-\begin{solution}
 Un tenseur $\uuline{A}$ peut être décomposé en une partie sphérique $\uuline{A}^{s}$, proportionnelle au tenseur unitaire $\uuline{I}$, et une partie déviatoire, $\uuline{A}^{d}$. On a donc : $\uuline{A} = \uuline{A^s} + \uuline{A}^d$.
 
 On calcule les deux composantes comme ceci :
@@ -112,12 +117,10 @@ et donc comme $\uuline{\sigma} = \uuline{\tau} - p\uuline{I}$ :
 
 
 Cette écriture permet d'identifier les deux types de viscosités, à savoir la \textit{viscosité (dynamique) de cisaillement $\mu$}, associée à la partie ``déviatoire'', et la \textit{viscosité (dynamique) de dilation/volume $\lambda + \frac{2}{3} \mu$}, associée à la partie ``sphérique''.
-\end{solution}
 
-\item Utiliser la loi de comportement d'un matériau hyper-élastique pour illustrer \textbf{deux}
-principes d'établissement de lois de constitution.
+\item
 
-\nosolution
+\nosubsolution
 %Je ne suis pas très sûr ici, besoin de confirmations/infiramtions
 
 %\paragraph{Admissibilité} la loi de constitution doit respecter le second principe de la thermodynamique, via l'inégalité de Clausius-Duhem :
@@ -125,11 +128,8 @@ principes d'établissement de lois de constitution.
 %\rho T \PTDeriv{S}{T} - \rho \PTDeriv{e}{t} \geq \frac{1}{T} \textbf{q} \cdot \nabla T - \uuline{\sigma}:\uuline{D}
 %\end{equation}
 
-\item Montrer que dans le cas d’un fluide visqueux newtonien incompressible et indatable,
-une condition nécessaire sur l’écoulement est que son champ de vitesse soit à divergence
-nulle? Pour ce cas, simplifier l’expression de la loi de constitution des contraintes.
+\item
 
-\begin{solution}
 On part de la conservation de la masse dans sa forme locale :
 \begin{equation}
 \PTDeriv{\rho}{t} + \rho \nabla \cdot \textbf{v} = \PDeriv{\rho}{t} + \textbf{v} \cdot \nabla \rho + \rho \nabla \cdot \textbf{v} = 0
@@ -152,8 +152,8 @@ On peut observer que $\mathrm{Tr}(\uuline{D}) = \PDeriv{v_i}{x_i} = \nabla \cdot
 \uuline{\sigma} = 2 \mu \uuline{D} - p\uuline{I}
 \end{equation}
 
-\end{solution}
 \end{enumerate}
+\end{solution}
 
 \includepdf[pages={3}]{mmc-MECA1901-exam-2014-Janvier-Mineure-Official.pdf}
 \ifthenelse{\equal{\Sol}{false}}{}

--- a/src/q4/mmc-MECA1901/exam/2014/Juin/All/mmc-MECA1901-exam-2014-Juin-All.tex
+++ b/src/q4/mmc-MECA1901/exam/2014/Juin/All/mmc-MECA1901-exam-2014-Juin-All.tex
@@ -9,8 +9,15 @@
 \section{Théorie}
 \begin{enumerate}
   \item Interpréter le terme $D_{11}$ du tenseur des taux de déformation. Utiliser un dessin pour votre explication.
+  \item Qu'est-ce que la trace d’un tenseur? Illustrez son utilisation dans deux concepts vus au cours (en cinématique, en dynamique,...).
+  \item Illustrez le principe d’admissibilité (thermodynamique) dans son utilisation pour établir deux lois de comportement (en mécanique des fluides, élasticité, transfert de chaleur,...).
+  \item Enoncez le principe de Saint-Venant, et illustrez son utilité dans la résolution de problèmes en mécanique du solide.
+\end{enumerate}
 
 \begin{solution}
+\begin{enumerate}
+\item
+
 Rappelons d'abord la définition de $D_{11}$ en coordonnées cartésiennes :
 
 \begin{equation}
@@ -18,12 +25,8 @@ D_{11}= \PDeriv{v_1}{x_1}
 \end{equation}
 
 Il s'agit du \textit{taux de dilatation linéaire} associé à la direction $\Base{1}$ et comporte un seul terme mesurant la variation de la vitesse en $\Base{1}$ selon $\Base{1}$.
-\end{solution}
 
-
-\item Qu'est-ce que la trace d’un tenseur? Illustrez son utilisation dans deux concepts vus au cours (en cinématique, en dynamique,...).
-
-\begin{solution}
+\item
 
 La trace d’un tenseur d’ordre deux est la somme de ses termes diagonaux
 \[
@@ -33,12 +36,9 @@ Elle est utilisée par exemple dans l'équation locale de conservation de la mas
 \[
 	\bm{\nabla} \cdot \textbf{v}=\mathrm{Tr}(\textbf{D})=0
 \]
-	
-\end{solution}	
 
-\item Illustrez le principe d’admissibilité (thermodynamique) dans son utilisation pour établir deux lois de comportement (en mécanique des fluides, élasticité, transfert de chaleur,...).
+\item
 
-\begin{solution}
 \mypar{La loi de Fourier (en thermoélasticité)}
 Le principe d'admissiblité permet d'établir une loi de constitution  pour le flux de chaleur $\textbf{q}$. Pour respecter l'admissibilité, on doit respecter l'inégalité de Clausius-Duhem qui se simplifie en :
 
@@ -77,16 +77,14 @@ Les deux termes du membre de gauche s'annulent donc mutuellement. En notation in
 \end{equation}
 
 Pour garantir cette inégalité pour toutes les valeurs de $D_{ij}$ et $\PDeriv{T}{x_i}$ on a nécessairement : $k > 0$ (voir plus haut) et $\mu \geq 0$. Dans ce cas, l'admissibilité est garantie.
-\end{solution}
 
+\item
 
-\item Enoncez le principe de Saint-Venant, et illustrez son utilité dans la résolution de problèmes en mécanique du solide.
-
-\begin{solution}
 Le principe de Saint-Venant nous dit qu'on peut remplacer la distribution des forces de contact imposées à une interface par une autre distribution statiquement équivalente (i.e. intégrale des forces identique) sans influencer de manière significative la solution à distance suffisamment grande de l'interface.
 
 Par exemple, pour calculer la charge sur une poutre encastrée, on peut remplacer la distribution de forces de contact (à priori compliquée) par une force distribuée continument sur toute la surface de l'extrémité de la poutre.
-\end{solution}
+
 \end{enumerate}
+\end{solution}
 
 \end{document}

--- a/src/q4/mmc-MECA1901/exam/2015/Janvier/Mineure/mmc-MECA1901-exam-2015-Janvier-Mineure.tex
+++ b/src/q4/mmc-MECA1901/exam/2015/Janvier/Mineure/mmc-MECA1901-exam-2015-Janvier-Mineure.tex
@@ -10,8 +10,17 @@
 
 \begin{enumerate}
   \item Prouver en utilisant la notation indicielle que $\nabla \wedge \nabla \alpha = 0$ pour un champ scalaire $\alpha$
+  \item Interpréter le terme $D_{12}$
+  \item Soit un milieu en contrainte bi-axiale : $\sigma_1>\sigma_2>0$. Dessiner le cercle de Mohr et donner la contrainte tangentielle max et la facette ou celle-ci est la plus grande
+  \item Expliquer le théorème de Green-Naghdi-Rivlin. Enoncer brièvement comment le prouver.
+  \item Montrer comment on peut simplifier la loi de constitution d'un fluide visqueux Newtonien dans le cas incompressible.
+\end{enumerate}
+
 
 \begin{solution}
+\begin{enumerate}
+\item
+
 Réecrivons l'expression en notation indicielle:
 \begin{align}
 \nabla \wedge \nabla \alpha & =\left(\bm{\hat{e_j}}\frac{\partial}{\partial x_j}\right) \wedge \left(\frac{\partial a}{\partial x_i}\bm{\hat{e_i}}\right)\\
@@ -27,39 +36,27 @@ On peut écrire, pour la $k^{\text{ième}}$ composante du vecteur:
 Pour écrire la première ligne, nous utilisons la définition du symbôle de \textit{levi-civata}. La seconde ligne est obtenue en renommant i, j et inversément. La dernière ligne est obtenue grâce à la symétrie de $\epsilon_{ijk}\bm{\hat{e_k}}\frac{\partial^2 a}{\partial x_i \partial x_j}$.
 
 On remarque que l'expression est égale à son opposée et ceci n'est vrai que dans le cas où elle est nulle. On en conclut donc que $\nabla \wedge \nabla \alpha = 0$.
-\end{solution}
 
 \item
-Interpréter le terme $D_{12}$
 
-\begin{solution}
 La définition de $D_{12}$ en coordonnées cartésiennes est donnée par:
 \begin{equation*}
 D_{12}=D_{21}=\frac{1}{2}\left(\frac{\partial v_1}{\partial x_2}+\frac{\partial v_2}{\partial x_1}\right)
 \end{equation*}
 Il s'agit du taux de déformation associé aux directions $e_1$, $e_2$.
-\end{solution}
 
 \item
-Soit un milieu en contrainte bi-axiale : $\sigma_1>\sigma_2>0$. Dessiner le cercle de Mohr et donner la contrainte tangentielle max et la facette ou celle-ci est la plus grande
 
-\begin{solution}
 Dans un milieu en contrainte bi-axiale, il y a deux contraintes principales non nulles et une contrainte principale nulle. Pour trouver la contrainte tangentielle maximale, il faut se promener sur le cercle de Mohr extérieur, celui qui représente le plan formé par les directions principales associées à $\sigma_1$ et 0. La contrainte tangentielle maximale est obtenue lorsqu'on a parcouru un angle de 90 degrés. Ce qui correspond, dans le problème à la bissectrice entre les deux directions principales qui forment ce plan. La contrainte tangentielle maximale est donnée par $\frac{\sigma_1}{2}$.
-\end{solution}
 
 \item
-Expliquer le théorème de Green-Naghdi-Rivlin. Enoncer brièvement comment le prouver.
 
-\begin{solution}
 Le théorème de Green-Naghdi-Rivlin stipule que, à partir des l'expression de la conservation de l'énergie et du principe d'invariance pour les mouvements rigides, on peut dériver les expressions de la conservation de la masse, de la quantité de mouvement et du moment de la quantité de mouvement. Le principe d'invariance pour les mouvements rigides stipule que l'expression de la conservation de l'énergie est encore vérifiée même si le milieu est soumis à un mouvement rigide (translation, rotation).
 
 Pour le démontrer, il faut considérer séparément un mouvement de translation simple et de rotation rigide. Le principe d'invariance nous permet de réecrire l'équation de la conservation de l'énergie en tenant compte des changements apportés. Dans le cas de la translation, seule l'expression de la vitesse est modifiée tandis que dans le cas de la rotation rigide, la vitesse et les forces à distances sont modifiées (ajout de Coriolis et de la force centrifuge qui sont des forces fictives).
-\end{solution}
 
 \item
-Montrer comment on peut simplifier la loi de constitution d'un fluide visqueux Newtonien dans le cas incompressible.
 
-\begin{solution}
 La loi de constitution d'un fluide visqueux Newtonien est donnée par:
 \begin{equation*}
 \sigma=2\mu \cal{D}+\lambda (\text{tr}\cal{D})\cal{I}-\text{p}\cal{I}
@@ -72,7 +69,8 @@ On trouve que $\nabla\cdot \bm{v}=0$, et donc on peut dire que la trace du tense
 \begin{equation*}
 \sigma=2\mu \cal{D}-\text{p}\cal{I}
 \end{equation*}
-\end{solution}
+
 \end{enumerate}
+\end{solution}
 
 \end{document}

--- a/src/q4/mmc-MECA1901/exam/2017/Janvier/Maj/mmc-MECA1901-exam-2017-Janvier-Maj.tex
+++ b/src/q4/mmc-MECA1901/exam/2017/Janvier/Maj/mmc-MECA1901-exam-2017-Janvier-Maj.tex
@@ -22,6 +22,8 @@ Pourquoi peut-on dire que $h(\hat{\mathbf{n}})=-\mathbf{q}\cdot \hat{\mathbf{n}}
 A partir de quelle forme géométrique ou relation établit-on cette relation? 
 Donnez un exemple de loi de constitution impliquant le flux de chaleur $\mathbf{q}$. Expliquez ensuite pourquoi cette loi est admissible.
 
+\nosolution
+
 \section{}
 Un point matériel subit la transformation décrite ci dessous quand $t>0$ :
 \begin{equation}
@@ -50,6 +52,8 @@ sachant que $\mathbf{B}=\mathbf{F}^T \cdot \mathbf{F}$, que $g(t)$, $J=det(F)$ e
 	
 \end{enumerate}
 
+\nosolution
+
 \section{Exercice}
 
 Même question que Q2 mineure janvier 2014 avec deux questions supplémentaires:
@@ -65,5 +69,7 @@ Même question que Q2 mineure janvier 2014 avec deux questions supplémentaires:
 	\item Vérifier la conservation de la quantité de mouvement sur un volume de contrôle pour le fluide intérieur.
 	\item Bonus : Vérifier la conservation de l'énergie sur un volume de contrôle pour le fluide intérieur.
 \end{enumerate}
+
+\nosolution
 
 \end{document}

--- a/src/q4/mmc-MECA1901/exam/2018/Janvier/Mineure/mmc-MECA1901-exam-2018-Janvier-Mineure.tex
+++ b/src/q4/mmc-MECA1901/exam/2018/Janvier/Mineure/mmc-MECA1901-exam-2018-Janvier-Mineure.tex
@@ -22,5 +22,7 @@
     
 \end{enumerate}
 
+\nosolution
+
 \end{document}
 

--- a/src/q4/os-SINF1252/exam/2016/Septembre/Majeure/os-SINF1252-exam-2016-Septembre-Majeure.tex
+++ b/src/q4/os-SINF1252/exam/2016/Septembre/Majeure/os-SINF1252-exam-2016-Septembre-Majeure.tex
@@ -191,7 +191,11 @@ return counter;
   \includegraphics[width=0.5\textwidth]{prodcons.png}
 \end{figure}
 
+\makeatletter
+\@checksolution
 \subsection{Fonction \texttt{insert}}
+\@checkstatement
+\makeatother
 
 Une librairie supportant un buffer partagé utilisé pour résoudre le problème des
 ``Producteurs/Consommateurs'' est implémentée comme suit.
@@ -257,6 +261,9 @@ sem_post(&(sp->items));
 \end{solution}
 
 \subsection{Fonction \texttt{remove}}
+\makeatletter
+\@checkstatement
+\makeatother
 
 Implémentez ici la fonction suivante
 

--- a/src/q4/sigsys-EPL1106/exam/2018/Juin/All/sigsys-EPL1106-exam-2018-Juin-All.tex
+++ b/src/q4/sigsys-EPL1106/exam/2018/Juin/All/sigsys-EPL1106-exam-2018-Juin-All.tex
@@ -31,4 +31,6 @@ On considère la séquence $x[n]=\cos(n\Omega_0)$ avec $\Omega_0=2\pi K/N$ où $
  \label{graphe}
 \end{figure}
 
+\nosolution
+
 \end{document}


### PR DESCRIPTION
As discussed previously (and suggested in #630 ).
With this commit, all documents that make use of the `eplqa.sty` package (that is, `epleval.cls` and its two derivatives `eplexam.cls` and `epltest.cls`, `eplmcq.cls`, `eplexercises.cls`, and obviously all documents that use these classes) now need to use `\begin{solution} ... \end{solution}` or `\nosolution`, otherwise the compilation fails.
This is a bit extreme and not really user-friendly, but I've tried putting comprehensive error messages so that the user knows how to fix it.
I've not yet tried compiling all files to correct the offending documents, I'll try to do it in the coming hours.

Regarding the use of `\nostatement`: for now, the code enforces the user to put a (no)solution after it. I don't know what's the best approach to deal with it, as it is only used twice in the whole repo, for Oz exams where we have the code but no statement (wtf). I think it's doable to make the (no)solution optional in this case by hacking the flags in the code, but maybe not worth it.

Also, it's maybe also doable, in case of questions/answers where there are multiple subquestions, to enforce that the structure (`itemize`/`enumerate`) match in the statement and in the solution. But much more difficult.

(It's a relatively old idea, so the author date is partially wrong.)