### PR TITLE
Fix styling of \section in epleval.cls + fix baseline of label

### DIFF
--- a/src/epleval.cls
+++ b/src/epleval.cls
@@ -58,8 +58,8 @@
 \titleformat
 {\section} % command
 [hang] % shape
-{\bfseries} % format
-{\shadowbox{~\thesection~}} % label
+{\mdseries\Large\sffamily\upshape} % format
+{\raisebox{-\shadowsize}{\shadowbox{\bfseries\rmfamily\normalsize~\thesection~}}} % label ; note: \fboxsep is the padding
 {0.5ex} % sep
 {} % before-code
 


### PR DESCRIPTION
Fixes #841

Styling unified to that of sans-serif fonts for all sectioning titles.
Label (in a shadow box) aligned such that the lower bound of the white box is aligned with the baseline of the section title.

Alternative fix would be to make all sectioning titles be in serif font.
Also, the size of the `\section` title is maybe too big, but it's the standard size (well, slightly smaller).

Any opinion is welcome ;)