### PR TITLE
Fixes some solution number woes

### DIFF
--- a/src/epleval.cls
+++ b/src/epleval.cls
@@ -63,9 +63,9 @@
 {0.5ex} % sep
 {} % before-code
 
-\newcommand{\QAlabel}{\IfLanguageName{english}{}{la }Question}
-\newcommand{\theQA}{\thesection}
-
 \RequirePackage[eval]{../../../../../../eplqa}
+
+\newcommand{\QAlabel}{\IfLanguageName{english}{}{la }Question}
+\renewcommand{\theQA}{\thesection}
 
 \endinput

--- a/src/eplexercises.cls
+++ b/src/eplexercises.cls
@@ -50,11 +50,9 @@
 {0.5ex} % sep
 {} % before-code
 
+\RequirePackage{../../../eplqa}
 
 \newcommand{\QAlabel}{\IfLanguageName{english}{Exercise}{l'Exercice}}
-\newcommand{\theQA}{\thesubsection}
-
-\RequirePackage{../../../eplqa}
 
 % \comment and \endcomment of the environment solution
 % does not work with newcommand

--- a/src/eplmcq.cls
+++ b/src/eplmcq.cls
@@ -41,9 +41,9 @@
 {} % before-code
 
 
-\newcommand{\QAlabel}{\IfLanguageName{english}{MCQ}{le QCM}}
-\newcommand{\theQA}{\thesubsection}
-
 \RequirePackage{../../../eplqa}
+
+\newcommand{\QAlabel}{\IfLanguageName{english}{MCQ}{le QCM}}
+\renewcommand{\theQA}{\thesubsection}
 
 \endinput

--- a/src/eplqa.sty
+++ b/src/eplqa.sty
@@ -31,9 +31,13 @@
 \ifthenelse{\equal{\Sol}{false}}
 {
   \newenvironment{solution}{\expandafter\comment}{\expandafter\endcomment}
+  \newenvironment{solution*}{\expandafter\comment}{\expandafter\endcomment}
 }
 {
+  \RequirePackage{etoolbox}
   \newmdenv[style=mysquare]{solution}
+  \newmdenv[style=mysquare]{solution*}
+  \AtBeginEnvironment{solution*}{\renewcommand{\SolutionLabel}{Solution}}
 }
 
 \NewDocumentEnvironment{solfig}{mm}

--- a/src/eplqa.sty
+++ b/src/eplqa.sty
@@ -9,6 +9,9 @@
 \usepackage{tikzpagenodes}
 \usetikzlibrary{calc, arrows}
 
+\RequirePackage{titlesec} % Provides the \thetitle command.
+\newcommand{\theQA}{\thetitle} % Default definition of this command: it uses the current section/subsection/... label
+
 \newcommand{\SolutionLabel}{Solution \IfLanguageName{english}{to}{à} \QAlabel~\theQA}
 
 \usepackage[framemethod=tikz]{mdframed}


### PR DESCRIPTION
- Adds a `solution*` environment. This one doesn't display the number of the question/exercise, so it doesn't display the words "à la Question" or "à l'Exercice". The label is thus quite short, maybe too short.
- By default, the solution now uses `\thetitle`, provided by `titlesec`, as label. This adapts to sections, subsections, even paragraphs. Of course, starred sections (that don't change the counter) have still a problem with it, but this is only marginally problematic.
