### PR TITLE
Update mmc-MECA1901-exam-2019-Janvier-Majeure.tex

### DIFF
--- a/src/q4/mmc-MECA1901/exam/2019/Janvier/Majeure/mmc-MECA1901-exam-2019-Janvier-Majeure.tex
+++ b/src/q4/mmc-MECA1901/exam/2019/Janvier/Majeure/mmc-MECA1901-exam-2019-Janvier-Majeure.tex
@@ -128,7 +128,7 @@ On considère une transformation uniforme définie par son gradient de déformat
 F_{11}(t) = f(t) \ \text{cos} (\omega t) \ ; \ 
 F_{22}(t) = f(t) \ ;  \
 F_{33}(t) = 1 \ ;  \
-F_{12}(t) = f(t) \ \cos (\omega t)
+F_{12}(t) = f(t) \ \sin (\omega t)
 \end{equation*}
 
 Toutes les autres composantes $F_{ij}(t)$ étant nulles.  On désigne par $\omega \geq 0$ une constante donnée, $t \geq 0$ le temps, et $f(t)$ une fonction continue dérivable qui vérifie : $f(0)=1$ et $f(t)>0, \ \forall \ t>0$.


### PR DESCRIPTION
typo en recopiant l'énoncé, toute la correction est basée sur un tenseur F différent