### PR TITLE
Ajout de l'exam d'ELEC2900 de Juin 2022

### DIFF
--- a/src/q8/sigproc-ELEC2900/exam/2022/2022.mk
+++ b/src/q8/sigproc-ELEC2900/exam/2022/2022.mk
@@ -1,0 +1,2 @@
+YEAR=2022
+include ../../../exam.mk

--- a/src/q8/sigproc-ELEC2900/exam/2022/Juin/All/Makefile
+++ b/src/q8/sigproc-ELEC2900/exam/2022/Juin/All/Makefile
@@ -1,0 +1,2 @@
+MINMAJ=All
+include ../Juin.mk

--- a/src/q8/sigproc-ELEC2900/exam/2022/Juin/All/sigproc-ELEC2900-exam-2022-Juin-All.tex
+++ b/src/q8/sigproc-ELEC2900/exam/2022/Juin/All/sigproc-ELEC2900-exam-2022-Juin-All.tex
@@ -1,0 +1,46 @@
+\documentclass[en]{../../../../../../eplexam}
+\usepackage{../../../../../../eplunits}
+%\usepackage{amsmath}
+%\usepackage{amssymb}
+
+\hypertitle{sigproc}{8}{ELEC}{2900}{2022}{Juin}{All}
+{Julien Giunta}
+{Laurent Jacques, François Rottenberg and Luc Vandendorpe}
+
+\section{}
+
+We have a signal at $\SI{5}{\mega}$ samples/$\SI{\second}$ and we would like to know the same signal at a rate of $\SI{6}{\mega}$ samples/$\SI{\second}$
+
+\paragraph{1.1} Provide a structure base on polyphase components which implements this sampling rate conversion. Justify.
+
+\paragraph{1.2} We instead would like to obtain a solution based on the DFT. Explain which operations need to be performed by means of DFT/IDFT to obtain this sampling rate conversion. A plot is welcome.
+
+\nosolution
+
+\section{IIR filter design}
+
+In the context of the design of discrete time IIR filters from an analog prototype, explain the main differences that exist between the \textit{impulse invariance} and \textit{bilinear transform} methods. You can stay synthetic but you must define all the concepts you provide.
+
+\nosolution
+
+\section{Kalman filter}
+
+\paragraph{3.1} Given a (hidden) state vector $x_k \in \mathbb{R}^n$ and a measurement vector $y_k \in \mathbb{R}^m$ (with $k$ the discrete time step) related by a linear state-space representation, \textit{explain} the main assumptions supporting the estimation of the state vector $x_k$ and its covariance with a Kalman filter at each $k \geq 0$. Why are they useful ? 
+
+\paragraph{3.2} What are the definition of the (LMMSE) estimates $\hat{x}_{k|k}$ and $\hat{P}_{k|k}$, that is the (a posteriori) estimates of the state vector $x_k$ and its covariance ?
+
+$$\hat{x}_{k|k} = \framebox(80,20){} \;\;\; \hat{P}_{k|k} = \framebox(150,20){}$$
+
+\nosolution
+
+\section{Compressive sensing (CS)}
+
+Let us consider the (noiseless) general linear inverse problem (followed by CS)
+$$\mathbf{y} = \mathbf{\Phi x} \in \mathbb{R}^m$$
+where $\mathbf{y}$ is a measurement vector encoding (indirect) information about a signal $\mathbf{x} \in \mathbb{R}^n$.
+
+If $m < n$, what is the condition we must impose on the matrix $\mathbf{\Phi}$ to be sure that two distinct $k$-sparse signal $\mathbf{x}, \mathbf{x}'$ are sent to two distinct measurement vectors $\mathbf{y}$ and $\mathbf{y'}$ ? Explain why this condition is appropriate (define all the concepts used in your explanation).
+
+\nosolution
+
+\end{document}

--- a/src/q8/sigproc-ELEC2900/exam/2022/Juin/Juin.mk
+++ b/src/q8/sigproc-ELEC2900/exam/2022/Juin/Juin.mk
@@ -1,0 +1,2 @@
+MONTH=Juin
+include ../../2022.mk


### PR DESCRIPTION
Ajout de l'examen de "LELEC2900 - Signal processing" de Juin 2022. L'utilisation du package "eplunit" ne permet pas d'afficher les unités en local. Je n'ai donc pas su vérifier que l'utilisation de la commande \SI{\second} (par exemple) fonctionnait correctement.